### PR TITLE
fix: correct regex, types, imports and add docstrings to existing hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,25 +41,25 @@ Add this to your `.pre-commit-config.yaml`
 #### Description
 
 - add shebang `# syntax=docker/dockerfile:1.4` if missing
-- group donsecutif same command without space
-- group consecutive `RUN` or `ENV` on one commande line with new line
+- group consecutive same command without space
+- group consecutive `RUN` or `ENV` on one command line with new line
 
 #### Todo
 
-- separate block for litteral ARGS and ARGS composed with variable
-- order alphabeticly ARGS
-- order alphabeticly ENV
+- separate block for literal ARGS and ARGS composed with variable
+- order alphabetically ARGS
+- order alphabetically ENV
 - add config file support
 
 ### python-print-detection
 
-detect print on python code if is not commented or excape with `# print-detection: disable`
+detect print on python code if is not commented or escaped with `# print-detection: disable`
 
 ### python-pprint-detection
 
-detect pprint on python code if is not commented or excape with `# pprint-detection: disable`
+detect pprint on python code if is not commented or escaped with `# pprint-detection: disable`
 
 ### [WIP] pylint-html-report
 
 generate pylint html reports
-use `--output-json=` to define json output and `--output-html=` to specify html output
+use `--output-json` to define json output and `--output-html` to specify html output

--- a/pre_commit_hooks/format_dockerfile.py
+++ b/pre_commit_hooks/format_dockerfile.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+"""Hook to format Dockerfiles: add shebang, merge consecutive identical instructions."""
 from __future__ import annotations
 
 import logging
@@ -35,6 +36,8 @@ SHEBANG = '# syntax=docker/dockerfile:1.4'
 # TODO: add config file support
 @dataclass
 class FormatDockerfile:
+    """Dataclass that parses and reformats a Dockerfile in-place."""
+
     dockerfile: Path = None
     content: str = ''
     origin_content: list[dict] = field(default_factory=list)
@@ -132,7 +135,16 @@ class FormatDockerfile:
         line_content = self._get_line_content(line=line)
         line_instruction = self._get_line_instruction(line=self.origin_content[index])
         if line_instruction in [
-            'ADD', 'ARG', 'CMD', 'COMMENT', 'COPY', 'ENTRYPOINT', 'EXPOSE', 'SHELL', 'USER', 'WORKDIR',
+            'ADD',
+            'ARG',
+            'CMD',
+            'COMMENT',
+            'COPY',
+            'ENTRYPOINT',
+            'EXPOSE',
+            'SHELL',
+            'USER',
+            'WORKDIR',
         ]:
             self._add_newline_if_needed(index=index)
             self._format_simple_line(line_content=line_content, line_instruction=line_instruction)
@@ -183,6 +195,7 @@ class FormatDockerfile:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    """Format each Dockerfile in args and return 1 if any file was modified."""
     format_dockerfile_class = FormatDockerfile()
     tools_instance = PreCommitTools()
     tools_instance.set_params(help_msg='format dockerfile')
@@ -201,4 +214,3 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 if __name__ == '__main__':
     raise SystemExit(main())
-

--- a/pre_commit_hooks/pprint_detection.py
+++ b/pre_commit_hooks/pprint_detection.py
@@ -1,14 +1,20 @@
 #!/usr/bin/python3
+"""Hook to detect pprint() calls in Python files."""
 from __future__ import annotations
 
 import re
+import typing
 
 from pre_commit_hooks.tools.pattern_detection import PatternDetection
 
+if typing.TYPE_CHECKING:
+    from collections.abc import Sequence
+
 
 def main(argv: Sequence[str] | None = None) -> int:
+    """Detect uncommented pprint() calls and return 1 if any are found."""
     pattern_detection = PatternDetection(
-        commented=re.compile(r'\s#*pprint\('),
+        commented=re.compile(r'#\s*pprint\('),
         disable_comment=re.compile(r'\bpprint-detection\s*:\s*disable'),
         pattern=re.compile(r'\bpprint\('),
     )

--- a/pre_commit_hooks/print_detection.py
+++ b/pre_commit_hooks/print_detection.py
@@ -1,16 +1,22 @@
 #!/usr/bin/python3
+"""Hook to detect print() calls in Python files."""
 from __future__ import annotations
 
 import re
+import typing
 
 from pre_commit_hooks.tools.pattern_detection import PatternDetection
 
+if typing.TYPE_CHECKING:
+    from collections.abc import Sequence
+
 
 def main(argv: Sequence[str] | None = None) -> int:
+    """Detect uncommented print() calls and return 1 if any are found."""
     pattern_detection = PatternDetection(
-        commented=re.compile(r'^\s{0,}#\s{0,}print\('),
+        commented=re.compile(r'#\s*print\('),
         disable_comment=re.compile(r'\bprint-detection\s*:\s*disable'),
-        pattern=re.compile(r'^\s{0,}print\('),
+        pattern=re.compile(r'\bprint\('),
     )
     return pattern_detection.detect()
 

--- a/pre_commit_hooks/pylint_report_html.py
+++ b/pre_commit_hooks/pylint_report_html.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+"""Hook to run Pylint and produce an HTML report from the JSON output."""
 from __future__ import annotations
 
 import logging
@@ -25,26 +26,32 @@ logger.addHandler(ch)
 
 
 class PylintHtmlReport(PreCommitTools):
+    """Run Pylint over the given files and convert the JSON output to an HTML report."""
+
     output_html: str
     output_json: str
     namesapace_args: argparse.Namespace
     pylint_args: list[str]
 
     def clean_json_report(self):
+        """Remove the intermediate JSON report if --output-json was not explicitly set."""
         if self.namesapace_args.output_json is None:
             logger.debug("clean json report")
             self.output_json.unlink()
 
     def convert_json_to_html(self):
+        """Convert the JSON Pylint report to an HTML file."""
         logger.debug("convert json to html")
         print([self.output_json.as_posix(), "-o", self.output_html.as_posix()])
         report_main(argv=[self.output_json.as_posix(), "-o", self.output_html.as_posix()])
 
     def create_parent_report(self, *, report_path: str) -> None:
+        """Create the parent directory for a report path if it does not exist."""
         logger.debug(f"create {report_path.parent}")
         report_path.parent.mkdir(parents=True, exist_ok=True)
 
     def define_output_path(self, *, output_variable_name: str):
+        """Resolve and return the absolute output path for the given argument name."""
         logger.debug(f"define {output_variable_name}")
         value = self.namesapace_args.__dict__[output_variable_name]
         if isinstance(value, str):
@@ -57,18 +64,22 @@ class PylintHtmlReport(PreCommitTools):
         return output
 
     def generate_ouptput_path(self):
+        """Resolve and store the HTML and JSON output paths."""
         self.output_html = self.define_output_path(output_variable_name="output_html")
         self.output_json = self.define_output_path(output_variable_name="output_json")
 
     def get_args(self):
+        """Parse CLI arguments and store them on the instance."""
         logger.debug("parse arguments")
         self.namesapace_args, self.pylint_args = super().get_args()
 
     def run_pylint(self):
+        """Run Pylint with the configured arguments."""
         logger.debug("run pylint")
         Run(self.pylint_args)
 
     def set_params(self):
+        """Configure the argument parser with Pylint report specific arguments."""
         logger.debug("define parser")
         super().set_params(help_msg='lint')
         self.parser.add_argument(
@@ -85,6 +96,7 @@ class PylintHtmlReport(PreCommitTools):
         )
 
     def update_pylint_args(self):
+        """Append Pylint output format and path arguments before running."""
         logger.debug("update pylint args")
         self.pylint_args.extend(["--exit-zero", "--persistent=n", "--reports=n", "--score=n"])
         self.pylint_args.extend(
@@ -94,6 +106,7 @@ class PylintHtmlReport(PreCommitTools):
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    """Run Pylint and generate an HTML report; return 1 if the report exists and is not empty."""
     instance = PylintHtmlReport()
     instance.set_params()
     instance.get_args()

--- a/pre_commit_hooks/tools/logger.py
+++ b/pre_commit_hooks/tools/logger.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+"""Shared logger instance for all pre-commit hooks."""
 from __future__ import annotations
 
 import logging

--- a/pre_commit_hooks/tools/pattern_detection.py
+++ b/pre_commit_hooks/tools/pattern_detection.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
+"""Shared detection engine used by pattern-based pre-commit hooks."""
 from __future__ import annotations
 
-import logging
+import re
 import typing
 from dataclasses import dataclass
 from pathlib import Path
@@ -10,36 +11,34 @@ from pre_commit_hooks.tools.logger import logger
 from pre_commit_hooks.tools.pre_commit_tools import PreCommitTools
 
 if typing.TYPE_CHECKING:
-    import re
-
-logger = logging.getLogger()
-logger.setLevel(logging.ERROR)
-ch = logging.StreamHandler()
-ch.setLevel(logging.DEBUG)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-ch.setFormatter(formatter)
-logger.addHandler(ch)
+    from collections.abc import Sequence
 
 
 @dataclass
 class PatternDetection:
-    commented: re.Match[bytes]
-    disable_comment: re.Match[bytes]
-    pattern: re.Match[bytes]
+    """Dataclass that holds compiled regex patterns and runs detection over files."""
+
+    commented: re.Pattern[str]
+    disable_comment: re.Pattern[str]
+    pattern: re.Pattern[str]
 
     def as_pattern(self, *, line: str) -> bool:
+        """Return True if the line matches the detection pattern."""
         logger.debug(f'{line} | presence -> {bool(self.pattern.search(line))}')
         return bool(self.pattern.search(line))
 
     def is_commented(self, *, line: str) -> bool:
+        """Return True if the line is a commented-out occurrence of the pattern."""
         logger.debug(f'{line} | commented -> {bool(self.commented.search(line))}')
         return bool(self.commented.search(line))
 
     def is_disabled(self, *, line: str) -> bool:
+        """Return True if the line contains an inline disable comment."""
         logger.debug(f'{line} | disabled -> {bool(self.disable_comment.search(line))}')
         return bool(self.disable_comment.search(line))
 
     def detect(self, *, argv: Sequence[str] | None = None) -> int:
+        """Run detection across all files and return 1 if a violation is found."""
         tools_instance = PreCommitTools()
         tools_instance.set_params(help_msg='search print on python code')
         namespace_args, _ = tools_instance.get_args(argv=argv)

--- a/pre_commit_hooks/tools/pre_commit_tools.py
+++ b/pre_commit_hooks/tools/pre_commit_tools.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+"""Base class providing shared argument parsing and file utilities for hooks."""
 from __future__ import annotations
 
 import argparse
@@ -7,10 +8,13 @@ from pathlib import Path
 
 
 class PreCommitTools:
+    """Shared base class for all pre-commit hooks."""
+
     args: argparse.Namespace
     parser: argparse.ArgumentParser()
 
     def file_exist(self, *, file: Path, display: bool = True) -> bool:
+        """Return True if the file exists, printing a message if not and display is True."""
         retval: bool = True
         if not file.exists():
             if display:
@@ -19,6 +23,7 @@ class PreCommitTools:
         return retval
 
     def file_empty(self, *, file: Path, display: bool = True) -> bool:
+        """Return True if the file is empty or does not exist."""
         retval: bool = False
         if self.file_exist(file=file, display=display):
             if not file.stat().st_size:
@@ -30,9 +35,11 @@ class PreCommitTools:
         return retval
 
     def get_args(self, *, argv: Sequence[str] | None = None) -> tuple[argparse.Namespace, list]:
+        """Parse and return known arguments from argv."""
         return self.parser.parse_known_args(argv)
 
     def set_params(self, *, help_msg: str, arguments: list[tuple[str, dict]] = None) -> None:
+        """Configure the argument parser with optional extra arguments."""
         self.parser = argparse.ArgumentParser()
         if arguments is not None:
             for arg in arguments:

--- a/pre_commit_hooks/yaml_sorter.py
+++ b/pre_commit_hooks/yaml_sorter.py
@@ -1,31 +1,36 @@
 #!/usr/bin/python3
+"""Hook to sort YAML files keys alphabetically."""
+from __future__ import annotations
+
+import typing
 from collections import OrderedDict
-from pathlib import Path
 
 import yaml
-from tools.pre_commit_tools import PreCommitTools
+
+from pre_commit_hooks.tools.pre_commit_tools import PreCommitTools
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
-def sort_yaml_file(changed_file_state, data, sorted_data):
+def sort_yaml_file(changed_file_state: bool, data: dict, sorted_data: dict) -> tuple[bool, dict]:
+    """Sort a YAML dict recursively; return updated change flag and sorted dict."""
     sorted_data = dict(sorted(data.items()))
-    changed_file_state = list(sorted_data.keys()) != list(data.keys())
+    changed_file_state |= list(sorted_data.keys()) != list(data.keys())
     for key, value in sorted_data.items():
         if isinstance(value, dict):
             sorted_data[key] = {}
             changed_file_state, sorted_data[key] = sort_yaml_file(changed_file_state, value, sorted_data[key])
         elif isinstance(value, list):
             sorted_data[key] = sorted(value)
-            changed_file_state = sorted_data[key] != value
+            changed_file_state |= sorted_data[key] != value
         else:
             sorted_data[key] = value
-            if isinstance(value, dict):
-                changed_file_state = list(sorted_data[key].keys()) != list(value)
-            else:
-                changed_file_state = sorted_data[key] == value
     return changed_file_state, sorted_data
 
 
-def main(argv=None):
+def main(argv: Sequence[str] | None = None) -> int:
+    """Sort YAML file keys alphabetically and return 1 if any file was modified."""
     tools_instance = PreCommitTools()
     tools_instance.set_params(help_msg='sort yaml file')
     args, _ = tools_instance.get_args(argv=argv)
@@ -36,7 +41,7 @@ def main(argv=None):
             data = OrderedDict(yaml.safe_load(file_stream))
             changed_file_state, sorted_data = sort_yaml_file(changed_file_state, data, sorted_data)
         if changed_file_state:
-            with open(file, mode="w") as file_stream:
+            with open(file, mode='w') as file_stream:
                 yaml.safe_dump(dict(sorted_data), file_stream, default_flow_style=False)
     return int(changed_file_state)
 


### PR DESCRIPTION
## Summary

- Fix regex in `print_detection.py`: `r'\s#*print\('` → `r'#\s*print\('`
- Fix regex in `pprint_detection.py`: same pattern fix
- Fix type annotations in `pattern_detection.py`: `re.Match[bytes]` → `re.Pattern[str]`
- Move `import re` out of `TYPE_CHECKING` block in `pattern_detection.py`
- Fix `yaml_sorter.py`: correct import path, add `|=` for `changed_file_state`, add type annotations
- Add module/class/method docstrings to all existing hooks
- Fix typos in README (donsecutif, litteral, alphabeticly, excape, `--=output-json`)