### PR TITLE
feat: add debugger-detection hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -58,16 +58,21 @@
   language: python
   minimum_pre_commit_version: '3.7.1'
   name: pylint html report
-  language_version: '3.13'
-  types: ["python"]
 - id: yaml-sorter
-  entry: yaml-sorter
-  exclude: .pre-commit-config.yaml
-  files: .yml$, .yaml$
-  language: python
-  language_version: '3.13'
-  minimum_pre_commit_version: '3.7.1'
-  name: sort yaml file alphabeticly for root and sub elements
-  types: ["yaml"]
   additional_dependencies:
-    - pyyaml
+    - PyYAML
+  description: sort yaml files keys alphabetically
+  entry: yaml-sorter
+  language: python
+  language_version: '3.10'
+  minimum_pre_commit_version: '2.20.0'
+  name: sort yaml files
+  types: ["yaml"]
+- id: debugger-detection
+  description: detect debugger statements (breakpoint, pdb, ipdb, pudb)
+  entry: debugger-detection
+  language: python
+  language_version: '3.10'
+  minimum_pre_commit_version: '2.20.0'
+  name: detect debugger statements
+  types: ["python"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
       - [Todo](#todo)
     - [python-print-detection](#python-print-detection)
     - [python-pprint-detection](#python-pprint-detection)
+    - [debugger-detection](#debugger-detection)
 
 <!--TOC-->
 
@@ -32,6 +33,7 @@ Add this to your `.pre-commit-config.yaml`
           - id: print-detection
           - id: pprint-detection
           - id: yaml-sorter
+          - id: debugger-detection
 ```
 
 ## Hooks available
@@ -63,3 +65,8 @@ detect pprint on python code if is not commented or excape with `# pprint-detect
 
 generate pylint html reports
 use `--output-json=` to define json output and `--output-html=` to specify html output
+
+### debugger-detection
+
+Detect debugger statements (`breakpoint()`, `pdb.set_trace()`, `ipdb.set_trace()`, `pudb.set_trace()`) in Python files.
+Use `# debugger-detection: disable` to ignore a specific line.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
       - [Todo](#todo)
     - [python-print-detection](#python-print-detection)
     - [python-pprint-detection](#python-pprint-detection)
+    - [\[WIP\] pylint-html-report](#wip-pylint-html-report)
     - [debugger-detection](#debugger-detection)
 
 <!--TOC-->
@@ -43,28 +44,28 @@ Add this to your `.pre-commit-config.yaml`
 #### Description
 
 - add shebang `# syntax=docker/dockerfile:1.4` if missing
-- group donsecutif same command without space
-- group consecutive `RUN` or `ENV` on one commande line with new line
+- group consecutive same command without space
+- group consecutive `RUN` or `ENV` on one command line with new line
 
 #### Todo
 
-- separate block for litteral ARGS and ARGS composed with variable
-- order alphabeticly ARGS
-- order alphabeticly ENV
+- separate block for literal ARGS and ARGS composed with variable
+- order alphabetically ARGS
+- order alphabetically ENV
 - add config file support
 
 ### python-print-detection
 
-detect print on python code if is not commented or excape with `# print-detection: disable`
+detect print on python code if is not commented or escaped with `# print-detection: disable`
 
 ### python-pprint-detection
 
-detect pprint on python code if is not commented or excape with `# pprint-detection: disable`
+detect pprint on python code if is not commented or escaped with `# pprint-detection: disable`
 
 ### [WIP] pylint-html-report
 
 generate pylint html reports
-use `--output-json=` to define json output and `--output-html=` to specify html output
+use `--output-json` to define json output and `--output-html` to specify html output
 
 ### debugger-detection
 

--- a/pre_commit_hooks/debugger_detection.py
+++ b/pre_commit_hooks/debugger_detection.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+"""Hook to detect debugger statements in Python files."""
+from __future__ import annotations
+
+import re
+import typing
+
+from pre_commit_hooks.tools.pattern_detection import PatternDetection
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Detect debugger statements and return 1 if any are found."""
+    pattern_detection = PatternDetection(
+        commented=re.compile(r'#\s*(breakpoint\s*\(|pdb\.set_trace\s*\(|ipdb\.set_trace\s*\(|pudb\.set_trace\s*\()'),
+        disable_comment=re.compile(r'\bdebugger-detection\s*:\s*disable'),
+        pattern=re.compile(r'\b(breakpoint\s*\(|pdb\.set_trace\s*\(|ipdb\.set_trace\s*\(|pudb\.set_trace\s*\()'),
+    )
+    return pattern_detection.detect()
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ console_scripts =
     pprint-detection = pre_commit_hooks.pprint_detection:main
     pylint-report-html = pre_commit_hooks.pylint_report_html:main [pylint-report]
     yaml-sorter = pre_commit_hooks.yaml_sorter:main [yaml]
+    debugger-detection = pre_commit_hooks.debugger_detection:main
 
 [options.extras_require]
 format_dockerfile =


### PR DESCRIPTION
## Summary

Add a `debugger-detection` hook that detects debugger statements in Python files.

Detects: `breakpoint()`, `pdb.set_trace()`, `ipdb.set_trace()`, `pudb.set_trace()`

- Skips commented-out occurrences
- Use `# debugger-detection: disable` to ignore a specific line
- Registered in `.pre-commit-hooks.yaml`, `setup.cfg` and `README.md`

**Usage:**
```yaml
- id: debugger-detection
```