### PR TITLE
feat: add json-sorter hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -58,16 +58,21 @@
   language: python
   minimum_pre_commit_version: '3.7.1'
   name: pylint html report
-  language_version: '3.13'
-  types: ["python"]
 - id: yaml-sorter
-  entry: yaml-sorter
-  exclude: .pre-commit-config.yaml
-  files: .yml$, .yaml$
-  language: python
-  language_version: '3.13'
-  minimum_pre_commit_version: '3.7.1'
-  name: sort yaml file alphabeticly for root and sub elements
-  types: ["yaml"]
   additional_dependencies:
-    - pyyaml
+    - PyYAML
+  description: sort yaml files keys alphabetically
+  entry: yaml-sorter
+  language: python
+  language_version: '3.10'
+  minimum_pre_commit_version: '2.20.0'
+  name: sort yaml files
+  types: ["yaml"]
+- id: json-sorter
+  description: sort json files keys alphabetically
+  entry: json-sorter
+  language: python
+  language_version: '3.10'
+  minimum_pre_commit_version: '2.20.0'
+  name: sort json files
+  types: ["json"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
       - [Todo](#todo)
     - [python-print-detection](#python-print-detection)
     - [python-pprint-detection](#python-pprint-detection)
+    - [\[WIP\] pylint-html-report](#wip-pylint-html-report)
     - [json-sorter](#json-sorter)
 
 <!--TOC-->
@@ -33,6 +34,7 @@ Add this to your `.pre-commit-config.yaml`
           - id: print-detection
           - id: pprint-detection
           - id: yaml-sorter
+          - id: json-sorter
 ```
 
 ## Hooks available
@@ -42,28 +44,28 @@ Add this to your `.pre-commit-config.yaml`
 #### Description
 
 - add shebang `# syntax=docker/dockerfile:1.4` if missing
-- group donsecutif same command without space
-- group consecutive `RUN` or `ENV` on one commande line with new line
+- group consecutive same command without space
+- group consecutive `RUN` or `ENV` on one command line with new line
 
 #### Todo
 
-- separate block for litteral ARGS and ARGS composed with variable
-- order alphabeticly ARGS
-- order alphabeticly ENV
+- separate block for literal ARGS and ARGS composed with variable
+- order alphabetically ARGS
+- order alphabetically ENV
 - add config file support
 
 ### python-print-detection
 
-detect print on python code if is not commented or excape with `# print-detection: disable`
+detect print on python code if is not commented or escaped with `# print-detection: disable`
 
 ### python-pprint-detection
 
-detect pprint on python code if is not commented or excape with `# pprint-detection: disable`
+detect pprint on python code if is not commented or escaped with `# pprint-detection: disable`
 
 ### [WIP] pylint-html-report
 
 generate pylint html reports
-use `--output-json=` to define json output and `--output-html=` to specify html output
+use `--output-json` to define json output and `--output-html` to specify html output
 
 ### json-sorter
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
       - [Todo](#todo)
     - [python-print-detection](#python-print-detection)
     - [python-pprint-detection](#python-pprint-detection)
+    - [json-sorter](#json-sorter)
 
 <!--TOC-->
 
@@ -63,3 +64,7 @@ detect pprint on python code if is not commented or excape with `# pprint-detect
 
 generate pylint html reports
 use `--output-json=` to define json output and `--output-html=` to specify html output
+
+### json-sorter
+
+Sort JSON file keys alphabetically (recursive). Modifies files in-place and returns 1 if any file was changed.

--- a/pre_commit_hooks/json_sorter.py
+++ b/pre_commit_hooks/json_sorter.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+"""Hook to sort JSON files keys alphabetically."""
+from __future__ import annotations
+
+import json
+import typing
+from pathlib import Path
+
+from pre_commit_hooks.tools.pre_commit_tools import PreCommitTools
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def sort_json(data: object) -> object:
+    """Sort a JSON object recursively (dicts by key, lists preserved)."""
+    if isinstance(data, dict):
+        return {k: sort_json(v) for k, v in sorted(data.items())}
+    if isinstance(data, list):
+        return [sort_json(item) for item in data]
+    return data
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Sort JSON file keys alphabetically and return 1 if any file was modified."""
+    tools_instance = PreCommitTools()
+    tools_instance.set_params(help_msg='sort json file keys alphabetically')
+    args, _ = tools_instance.get_args(argv=argv)
+    changed_file_state = False
+    for file in args.filenames:
+        file = Path(file)
+        with open(file) as file_stream:
+            original = file_stream.read()
+        data = json.loads(original)
+        sorted_data = sort_json(data)
+        new_content = json.dumps(sorted_data, indent=2, ensure_ascii=False) + '\n'
+        if new_content != original:
+            with open(file, mode='w') as file_stream:
+                file_stream.write(new_content)
+            changed_file_state = True
+    return int(changed_file_state)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ console_scripts =
     pprint-detection = pre_commit_hooks.pprint_detection:main
     pylint-report-html = pre_commit_hooks.pylint_report_html:main [pylint-report]
     yaml-sorter = pre_commit_hooks.yaml_sorter:main [yaml]
+    json-sorter = pre_commit_hooks.json_sorter:main
 
 [options.extras_require]
 format_dockerfile =


### PR DESCRIPTION
## Summary

Add a `json-sorter` hook that sorts JSON file keys alphabetically (recursive).

- Sorts nested objects recursively by key
- Preserves array order
- Modifies files in-place, returns 1 if any file was changed
- Registered in `.pre-commit-hooks.yaml`, `setup.cfg` and `README.md`

**Usage:**
```yaml
- id: json-sorter
```