### PR TITLE
feat: add requirements-sort hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -58,16 +58,22 @@
   language: python
   minimum_pre_commit_version: '3.7.1'
   name: pylint html report
-  language_version: '3.13'
-  types: ["python"]
 - id: yaml-sorter
-  entry: yaml-sorter
-  exclude: .pre-commit-config.yaml
-  files: .yml$, .yaml$
-  language: python
-  language_version: '3.13'
-  minimum_pre_commit_version: '3.7.1'
-  name: sort yaml file alphabeticly for root and sub elements
-  types: ["yaml"]
   additional_dependencies:
-    - pyyaml
+    - PyYAML
+  description: sort yaml files keys alphabetically
+  entry: yaml-sorter
+  language: python
+  language_version: '3.10'
+  minimum_pre_commit_version: '2.20.0'
+  name: sort yaml files
+  types: ["yaml"]
+- id: requirements-sort
+  description: sort requirements files alphabetically
+  entry: requirements-sort
+  files: 'requirements.*\.txt$'
+  language: python
+  language_version: '3.10'
+  minimum_pre_commit_version: '2.20.0'
+  name: sort requirements files
+  types: ["text"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
       - [Todo](#todo)
     - [python-print-detection](#python-print-detection)
     - [python-pprint-detection](#python-pprint-detection)
+    - [\[WIP\] pylint-html-report](#wip-pylint-html-report)
     - [requirements-sort](#requirements-sort)
 
 <!--TOC-->
@@ -33,6 +34,7 @@ Add this to your `.pre-commit-config.yaml`
           - id: print-detection
           - id: pprint-detection
           - id: yaml-sorter
+          - id: requirements-sort
 ```
 
 ## Hooks available
@@ -42,28 +44,28 @@ Add this to your `.pre-commit-config.yaml`
 #### Description
 
 - add shebang `# syntax=docker/dockerfile:1.4` if missing
-- group donsecutif same command without space
-- group consecutive `RUN` or `ENV` on one commande line with new line
+- group consecutive same command without space
+- group consecutive `RUN` or `ENV` on one command line with new line
 
 #### Todo
 
-- separate block for litteral ARGS and ARGS composed with variable
-- order alphabeticly ARGS
-- order alphabeticly ENV
+- separate block for literal ARGS and ARGS composed with variable
+- order alphabetically ARGS
+- order alphabetically ENV
 - add config file support
 
 ### python-print-detection
 
-detect print on python code if is not commented or excape with `# print-detection: disable`
+detect print on python code if is not commented or escaped with `# print-detection: disable`
 
 ### python-pprint-detection
 
-detect pprint on python code if is not commented or excape with `# pprint-detection: disable`
+detect pprint on python code if is not commented or escaped with `# pprint-detection: disable`
 
 ### [WIP] pylint-html-report
 
 generate pylint html reports
-use `--output-json=` to define json output and `--output-html=` to specify html output
+use `--output-json` to define json output and `--output-html` to specify html output
 
 ### requirements-sort
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
       - [Todo](#todo)
     - [python-print-detection](#python-print-detection)
     - [python-pprint-detection](#python-pprint-detection)
+    - [requirements-sort](#requirements-sort)
 
 <!--TOC-->
 
@@ -63,3 +64,7 @@ detect pprint on python code if is not commented or excape with `# pprint-detect
 
 generate pylint html reports
 use `--output-json=` to define json output and `--output-html=` to specify html output
+
+### requirements-sort
+
+Sort `requirements*.txt` files alphabetically (comments and blank lines first, then packages sorted case-insensitively). Modifies files in-place and returns 1 if any file was changed.

--- a/pre_commit_hooks/requirements_sort.py
+++ b/pre_commit_hooks/requirements_sort.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python3
+"""Hook to sort requirements files alphabetically."""
+from __future__ import annotations
+
+import typing
+from pathlib import Path
+
+from pre_commit_hooks.tools.pre_commit_tools import PreCommitTools
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def sort_requirements(lines: list[str]) -> list[str]:
+    """Sort requirements lines: comments/blanks first, packages sorted case-insensitively."""
+    comments = [line for line in lines if not line.strip() or line.strip().startswith('#')]
+    packages = [line for line in lines if line.strip() and not line.strip().startswith('#')]
+    sorted_packages = sorted(packages, key=lambda x: x.split('#')[0].strip().lower())
+    return comments + sorted_packages
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Sort requirements file alphabetically and return 1 if any file was modified."""
+    tools_instance = PreCommitTools()
+    tools_instance.set_params(help_msg='sort requirements file alphabetically')
+    args, _ = tools_instance.get_args(argv=argv)
+    changed_file_state = False
+    for file in args.filenames:
+        file = Path(file)
+        with open(file) as file_stream:
+            lines = file_stream.readlines()
+        sorted_lines = sort_requirements([line.rstrip('\n') for line in lines])
+        new_content = '\n'.join(sorted_lines) + '\n'
+        original = ''.join(lines)
+        if new_content != original:
+            with open(file, mode='w') as file_stream:
+                file_stream.write(new_content)
+            changed_file_state = True
+    return int(changed_file_state)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ console_scripts =
     pprint-detection = pre_commit_hooks.pprint_detection:main
     pylint-report-html = pre_commit_hooks.pylint_report_html:main [pylint-report]
     yaml-sorter = pre_commit_hooks.yaml_sorter:main [yaml]
+    requirements-sort = pre_commit_hooks.requirements_sort:main
 
 [options.extras_require]
 format_dockerfile =


### PR DESCRIPTION
## Summary

Add a `requirements-sort` hook that sorts `requirements*.txt` files alphabetically.

- Comments and blank lines are kept at the top
- Packages sorted case-insensitively (inline comments ignored for sort key)
- Modifies files in-place, returns 1 if any file was changed
- Registered in `.pre-commit-hooks.yaml`, `setup.cfg` and `README.md`

**Usage:**
```yaml
- id: requirements-sort
```