### PR TITLE
feat: add env-file-check hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -58,16 +58,22 @@
   language: python
   minimum_pre_commit_version: '3.7.1'
   name: pylint html report
-  language_version: '3.13'
-  types: ["python"]
 - id: yaml-sorter
-  entry: yaml-sorter
-  exclude: .pre-commit-config.yaml
-  files: .yml$, .yaml$
-  language: python
-  language_version: '3.13'
-  minimum_pre_commit_version: '3.7.1'
-  name: sort yaml file alphabeticly for root and sub elements
-  types: ["yaml"]
   additional_dependencies:
-    - pyyaml
+    - PyYAML
+  description: sort yaml files keys alphabetically
+  entry: yaml-sorter
+  language: python
+  language_version: '3.10'
+  minimum_pre_commit_version: '2.20.0'
+  name: sort yaml files
+  types: ["yaml"]
+- id: env-file-check
+  description: detect potential secrets committed in .env files
+  entry: env-file-check
+  files: '\.env'
+  language: python
+  language_version: '3.10'
+  minimum_pre_commit_version: '2.20.0'
+  name: check env files for secrets
+  types: ["text"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
       - [Todo](#todo)
     - [python-print-detection](#python-print-detection)
     - [python-pprint-detection](#python-pprint-detection)
+    - [\[WIP\] pylint-html-report](#wip-pylint-html-report)
+    - [env-file-check](#env-file-check)
 
 <!--TOC-->
 
@@ -32,6 +34,7 @@ Add this to your `.pre-commit-config.yaml`
           - id: print-detection
           - id: pprint-detection
           - id: yaml-sorter
+          - id: env-file-check
 ```
 
 ## Hooks available
@@ -41,25 +44,30 @@ Add this to your `.pre-commit-config.yaml`
 #### Description
 
 - add shebang `# syntax=docker/dockerfile:1.4` if missing
-- group donsecutif same command without space
-- group consecutive `RUN` or `ENV` on one commande line with new line
+- group consecutive same command without space
+- group consecutive `RUN` or `ENV` on one command line with new line
 
 #### Todo
 
-- separate block for litteral ARGS and ARGS composed with variable
-- order alphabeticly ARGS
-- order alphabeticly ENV
+- separate block for literal ARGS and ARGS composed with variable
+- order alphabetically ARGS
+- order alphabetically ENV
 - add config file support
 
 ### python-print-detection
 
-detect print on python code if is not commented or excape with `# print-detection: disable`
+detect print on python code if is not commented or escaped with `# print-detection: disable`
 
 ### python-pprint-detection
 
-detect pprint on python code if is not commented or excape with `# pprint-detection: disable`
+detect pprint on python code if is not commented or escaped with `# pprint-detection: disable`
 
 ### [WIP] pylint-html-report
 
 generate pylint html reports
-use `--output-json=` to define json output and `--output-html=` to specify html output
+use `--output-json` to define json output and `--output-html` to specify html output
+
+### env-file-check
+
+Detect potential secrets committed in `.env` files (passwords, tokens, API keys, etc.).
+Placeholder values (`<value>`, `${VAR}`, `changeme`, etc.) are ignored.

--- a/pre_commit_hooks/env_file_check.py
+++ b/pre_commit_hooks/env_file_check.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+"""Hook to detect potential secrets committed in .env files."""
+from __future__ import annotations
+
+import re
+import typing
+from pathlib import Path
+
+from pre_commit_hooks.tools.logger import logger
+from pre_commit_hooks.tools.pre_commit_tools import PreCommitTools
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Sequence
+
+_SECRET_KEY_RE = re.compile(
+    r'^(PASSWORD|PASSWD|SECRET|TOKEN|API_KEY|APIKEY|PRIVATE_KEY|AUTH_KEY|ACCESS_KEY|CREDENTIAL|CREDENTIALS'
+    r'|CLIENT_SECRET|OAUTH_SECRET|ENCRYPTION_KEY|SIGNING_KEY|MASTER_KEY)\s*=\s*(.+)$',
+    re.IGNORECASE,
+)
+_PLACEHOLDER_RE = re.compile(
+    r'^$|^<.+>$|^\$\{.+\}$|^%.+%$|^(?:your[-_]|change[-_]?me|todo|fixme|example|test|dummy|fake|none|null|false|true|0)$',
+    re.IGNORECASE,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Check .env files for committed secrets and return 1 if any are found."""
+    tools_instance = PreCommitTools()
+    tools_instance.set_params(help_msg='check .env files for committed secrets')
+    args, _ = tools_instance.get_args(argv=argv)
+    ret_val = 0
+    for file in args.filenames:
+        file = Path(file)
+        logger.debug(f'process file {file}')
+        with open(file) as file_stream:
+            for line_number, line_content in enumerate(file_stream.readlines()):
+                line_content = line_content.rstrip('\n')
+                if not line_content.strip() or line_content.strip().startswith('#'):
+                    continue
+                match = _SECRET_KEY_RE.match(line_content)
+                if match:
+                    value = match.group(2).strip().strip('"').strip("'")
+                    if not _PLACEHOLDER_RE.match(value):
+                        print(
+                            f'[{file}][L.{line_number}] potential secret committed: {match.group(1)}',
+                        )  # print-detection: disable
+                        ret_val = 1
+    return ret_val
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ console_scripts =
     pprint-detection = pre_commit_hooks.pprint_detection:main
     pylint-report-html = pre_commit_hooks.pylint_report_html:main [pylint-report]
     yaml-sorter = pre_commit_hooks.yaml_sorter:main [yaml]
+    env-file-check = pre_commit_hooks.env_file_check:main
 
 [options.extras_require]
 format_dockerfile =


### PR DESCRIPTION
## Summary

Add an `env-file-check` hook that detects potential secrets committed in `.env` files.

Detects keys like: `PASSWORD`, `TOKEN`, `API_KEY`, `SECRET`, `PRIVATE_KEY`, etc.

- Placeholder values are ignored (`<value>`, `${VAR}`, `changeme`, `todo`, `example`, etc.)
- Commented lines are skipped
- Returns 1 and prints `[file][L.N] potential secret committed: KEY` for each finding
- Registered in `.pre-commit-hooks.yaml`, `setup.cfg` and `README.md`

**Usage:**
```yaml
- id: env-file-check
```