### PR TITLE
feat: add logger-detection hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -58,16 +58,21 @@
   language: python
   minimum_pre_commit_version: '3.7.1'
   name: pylint html report
-  language_version: '3.13'
-  types: ["python"]
 - id: yaml-sorter
-  entry: yaml-sorter
-  exclude: .pre-commit-config.yaml
-  files: .yml$, .yaml$
-  language: python
-  language_version: '3.13'
-  minimum_pre_commit_version: '3.7.1'
-  name: sort yaml file alphabeticly for root and sub elements
-  types: ["yaml"]
   additional_dependencies:
-    - pyyaml
+    - PyYAML
+  description: sort yaml files keys alphabetically
+  entry: yaml-sorter
+  language: python
+  language_version: '3.10'
+  minimum_pre_commit_version: '2.20.0'
+  name: sort yaml files
+  types: ["yaml"]
+- id: python-logger-detection
+  description: detect direct use of root logging module instead of named logger
+  entry: logger-detection
+  language: python
+  language_version: '3.10'
+  minimum_pre_commit_version: '2.20.0'
+  name: detect root logger usage
+  types: ["python"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
       - [Todo](#todo)
     - [python-print-detection](#python-print-detection)
     - [python-pprint-detection](#python-pprint-detection)
+    - [\[WIP\] pylint-html-report](#wip-pylint-html-report)
+    - [logger-detection](#logger-detection)
 
 <!--TOC-->
 
@@ -32,6 +34,7 @@ Add this to your `.pre-commit-config.yaml`
           - id: print-detection
           - id: pprint-detection
           - id: yaml-sorter
+          - id: logger-detection
 ```
 
 ## Hooks available
@@ -41,25 +44,30 @@ Add this to your `.pre-commit-config.yaml`
 #### Description
 
 - add shebang `# syntax=docker/dockerfile:1.4` if missing
-- group donsecutif same command without space
-- group consecutive `RUN` or `ENV` on one commande line with new line
+- group consecutive same command without space
+- group consecutive `RUN` or `ENV` on one command line with new line
 
 #### Todo
 
-- separate block for litteral ARGS and ARGS composed with variable
-- order alphabeticly ARGS
-- order alphabeticly ENV
+- separate block for literal ARGS and ARGS composed with variable
+- order alphabetically ARGS
+- order alphabetically ENV
 - add config file support
 
 ### python-print-detection
 
-detect print on python code if is not commented or excape with `# print-detection: disable`
+detect print on python code if is not commented or escaped with `# print-detection: disable`
 
 ### python-pprint-detection
 
-detect pprint on python code if is not commented or excape with `# pprint-detection: disable`
+detect pprint on python code if is not commented or escaped with `# pprint-detection: disable`
 
 ### [WIP] pylint-html-report
 
 generate pylint html reports
-use `--output-json=` to define json output and `--output-html=` to specify html output
+use `--output-json` to define json output and `--output-html` to specify html output
+
+### logger-detection
+
+Detect direct use of the root `logging` module (e.g. `logging.info(...)`) instead of a named logger.
+Use `# logger-detection: disable` to ignore a specific line.

--- a/pre_commit_hooks/logger_detection.py
+++ b/pre_commit_hooks/logger_detection.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+"""Hook to detect direct use of the root logging module instead of a named logger."""
+from __future__ import annotations
+
+import re
+import typing
+
+from pre_commit_hooks.tools.pattern_detection import PatternDetection
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Detect direct root logging calls and return 1 if any are found."""
+    pattern_detection = PatternDetection(
+        commented=re.compile(r'#\s*logging\.(debug|info|warning|error|critical|exception)\s*\('),
+        disable_comment=re.compile(r'\blogger-detection\s*:\s*disable'),
+        pattern=re.compile(r'\blogging\.(debug|info|warning|error|critical|exception)\s*\('),
+    )
+    return pattern_detection.detect()
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ console_scripts =
     pprint-detection = pre_commit_hooks.pprint_detection:main
     pylint-report-html = pre_commit_hooks.pylint_report_html:main [pylint-report]
     yaml-sorter = pre_commit_hooks.yaml_sorter:main [yaml]
+    logger-detection = pre_commit_hooks.logger_detection:main
 
 [options.extras_require]
 format_dockerfile =


### PR DESCRIPTION
## Summary

Add a `logger-detection` hook that detects direct use of the root `logging` module instead of a named logger.

Detects: `logging.debug()`, `logging.info()`, `logging.warning()`, `logging.error()`, `logging.critical()`, `logging.exception()`

- Skips commented-out occurrences
- Use `# logger-detection: disable` to ignore a specific line
- Registered in `.pre-commit-hooks.yaml`, `setup.cfg` and `README.md`

**Usage:**
```yaml
- id: python-logger-detection
```