### PR TITLE
ci: configure dependabot for pip and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "pre-commit"


### PR DESCRIPTION
## Summary

Configure Dependabot to automatically keep dependencies up to date.

## Changes

- Add `.github/dependabot.yml`

### Pip ecosystem
- Weekly updates (Monday)
- Labels: `dependencies`, `python`

### GitHub Actions ecosystem
- Weekly updates (Monday)
- Labels: `dependencies`, `github-actions`