### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "fix: "
+labels: bug
+assignees: chrysa
+---
+
+## Description
+
+A clear and concise description of what the bug is.
+
+## Steps to reproduce
+
+1. Hook used: `<!-- e.g. console-log-detection -->`
+2. File type / extension targeted: `<!-- e.g. .js -->`
+3. `.pre-commit-config.yaml` configuration:
+
+```yaml
+# paste your hook config here
+```
+
+4. Command run:
+
+```sh
+pre-commit run <hook-id> --all-files
+```
+
+5. Observed behavior:
+
+<!-- What happened? -->
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Environment
+
+- OS: <!-- e.g. Ubuntu 22.04 -->
+- Python version: <!-- e.g. 3.13 -->
+- pre-commit version: <!-- e.g. 3.7.1 -->
+- pre-commit-tools version: <!-- e.g. 0.0.33 -->
+
+## Additional context
+
+Add any other context or screenshots about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,45 @@
+---
+name: Feature request
+about: Suggest an idea or improvement for this project
+title: "feat: "
+labels: enhancement
+assignees: chrysa
+---
+
+## Summary
+
+A clear and concise description of the feature or improvement you'd like.
+
+## Problem
+
+Describe the problem this feature would solve, or the limitation you're running into.
+
+## Suggested solution
+
+Describe the solution you'd like. Include relevant hook ids, file patterns, or configuration examples if applicable.
+
+```yaml
+# Example configuration
+```
+
+## Affected hooks
+
+<!-- List the hook(s) concerned, if any -->
+- [ ] `console-log-detection`
+- [ ] `console-debug-detection`
+- [ ] `console-table-detection`
+- [ ] `print-detection`
+- [ ] `pprint-detection`
+- [ ] `debugger-detection`
+- [ ] `logger-detection`
+- [ ] `yaml-sorter`
+- [ ] `json-sorter`
+- [ ] `requirements-sort`
+- [ ] `env-file-check`
+- [ ] `format-dockerfile`
+- [ ] `pylint-report-html`
+- [ ] Other / New hook
+
+## Additional context
+
+Add any other context, links, or screenshots here.


### PR DESCRIPTION
## Summary

Add GitHub issue templates to standardize bug reports and feature requests.

## Changes

- Add `.github/ISSUE_TEMPLATE/bug_report.md`
- Add `.github/ISSUE_TEMPLATE/feature_request.md`

### Bug report template
- Steps to reproduce, expected vs observed behavior
- Environment details (OS, Python, pre-commit, pre-commit-tools versions)
- Pre-filled label: `bug`

### Feature request template
- Problem description and suggested solution
- Checklist of affected hooks
- Pre-filled label: `enhancement`