### PR TITLE
feat: add helm-lint hook (language: system)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -256,4 +256,12 @@
   minimum_pre_commit_version: '4.1.0'
   name: validate JS/.gs syntax (node --check)
   types_or: ["javascript", "file"]
+- id: helm-lint
+  description: run helm lint --strict on all charts in charts/<namespace>/<service>/ (requires helm in PATH)
+  entry: bash -c 'find charts -mindepth 2 -maxdepth 2 -type d | while read d; do helm lint "$d" --strict || exit 1; done'
+  files: ^charts/
+  language: system
+  minimum_pre_commit_version: '4.1.0'
+  name: helm lint (charts/)
+  pass_filenames: false
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Add this to your `.pre-commit-config.yaml`
           - id: ts-unreachable-code
           - id: css-duplicate-property
           - id: css-unused-variable
+          # requires helm in PATH
+          - id: helm-lint
 ```
 
 ## Hooks available
@@ -458,5 +460,26 @@ Requires Node.js to be installed in PATH. If Node.js is not available, the hook 
 ```yaml
 - id: js-syntax-check
   files: '\.(js|gs)$'
+```
+
+### helm-lint
+
+Run `helm lint --strict` on all charts found in `charts/<namespace>/<service>/` (depth 2 under `charts/`).
+Requires `helm` to be installed in PATH.
+
+Expected directory structure:
+
+```text
+charts/
+  <namespace>/
+    <service>/     ← helm lint --strict is run here
+      Chart.yaml
+      values.yaml
+```
+
+```yaml
+- id: helm-lint
+  files: ^charts/
+  pass_filenames: false
 ```
 


### PR DESCRIPTION
## Summary

Add a `helm-lint` hook that runs `helm lint --strict` on all charts found in `charts/<namespace>/<service>/`.

This hook uses `language: system` and requires `helm` to be installed in PATH.

## Changes

- `.pre-commit-hooks.yaml` — add `helm-lint` hook definition
- `README.md` — document the new hook in usage block and hooks section

## Usage

```yaml
- repo: https://github.com/chrysa/pre-commit-tools
  rev: '<rev>'
  hooks:
    - id: helm-lint
```

Expected directory structure:
```
charts/
  <namespace>/
    <service>/     ← helm lint --strict is run here
      Chart.yaml
      values.yaml
```

## Related

Requested by chrysa/server — see cross-linked PR (pending).

## Prerequisites

- `helm` v3 installed in PATH