### PR TITLE
fix(pre-commit): update hook revisions to stable tags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: setup-cfg-fmt
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: f1dff44d3a9ae852957f34def96390f28719c232
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -69,7 +69,7 @@ repos:
         stages: [manual]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: c53b915162b475dfc95c73f94219e6f87ace2fca
+    rev: v0.11.2
     hooks:
       - id: ruff
         args: [--config=config-tools/ruff.toml, --fix]


### PR DESCRIPTION
Replace invalid tree SHAs with proper tag names (v5.0.0, v0.11.2).