### PR TITLE
fix(hooks): correct invalid files regex for format-dockerfiles

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,7 @@
     - dockerfile-parse
   description: format dockerfiles
   entry: format-dockerfile
-  files: Dockerfile, .[dD]ockerfile$
+  files: '(^|/)Dockerfile[^/]*$|(^|/)\.[Dd]ockerfile[^/]*$'
   language: python
   minimum_pre_commit_version: '4.1.0'
   name: format dockerfiles


### PR DESCRIPTION
## Problem

The `format-dockerfiles` hook had `files: Dockerfile, .[dD]ockerfile$` which is not a valid regex (the comma+space are literal characters, not alternation).

## Fix

Replace with `(^|/)Dockerfile[^/]*$|(^|/)\.[ Dd]ockerfile[^/]*$` which correctly matches:
- `Dockerfile`, `Dockerfile.dev`, `Dockerfile.prod`
- `.Dockerfile`, `.dockerfile`


Closes #52