### PR TITLE
fix(js-syntax-check): handle .gs files under Node.js 24 (ERR_UNKNOWN_FILE_EXTENSION)

### DIFF
--- a/pre_commit_hooks/js_syntax_check.py
+++ b/pre_commit_hooks/js_syntax_check.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import tempfile
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -27,8 +28,40 @@ def _check_node_available() -> bool:
         return True
 
 
+def _check_via_temp_js(filename: str) -> list[Violation]:
+    """Check .gs file by copying to a temp .js file (Node.js 24 workaround).
+
+    Node.js 24 raises ERR_UNKNOWN_FILE_EXTENSION for .gs files because it
+    enforces ES module resolution by extension. Copying to a .js temporary
+    file bypasses this restriction without changing the syntax being checked.
+    """
+    source = Path(filename).read_bytes()
+    with tempfile.NamedTemporaryFile(suffix='.js', delete=False) as tmp:
+        tmp.write(source)
+        tmp_path = tmp.name
+    try:
+        result = subprocess.run(
+            ['node', '--check', tmp_path],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return [(filename, f'node check failed: {exc}')]
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+    if result.returncode != 0:
+        error = (result.stderr or result.stdout).strip().replace(tmp_path, filename)
+        return [(filename, error)]
+    return []
+
+
 def check_syntax(filename: str) -> list[Violation]:
     """Run node --check on the file and return list of (filename, error_message)."""
+    # Node.js 24+ raises ERR_UNKNOWN_FILE_EXTENSION for .gs files.
+    # Use a temp .js file to bypass this limitation.
+    if Path(filename).suffix == '.gs':
+        return _check_via_temp_js(filename)
     try:
         result = subprocess.run(
             ['node', '--check', filename],

--- a/tests/test_js_syntax_check.py
+++ b/tests/test_js_syntax_check.py
@@ -66,3 +66,37 @@ class TestJsSyntaxCheckMain:
 
     def test_empty_args_returns_0(self) -> None:
         assert main([]) == 0
+
+
+class TestCheckViaTempJs:
+    def test_gs_file_clean_returns_empty(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'a.gs', 'var x = 1;\n')
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stderr = ''
+        with patch('subprocess.run', return_value=mock_result):
+            from pre_commit_hooks.js_syntax_check import _check_via_temp_js
+            result = _check_via_temp_js(f)
+        assert result == []
+
+    def test_gs_file_syntax_error_returns_violation(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'bad.gs', 'var = ;\n')
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = 'SyntaxError: Unexpected token'
+        mock_result.stdout = ''
+        with patch('subprocess.run', return_value=mock_result):
+            from pre_commit_hooks.js_syntax_check import _check_via_temp_js
+            result = _check_via_temp_js(f)
+        assert len(result) == 1
+        # Original filename preserved in violation
+        assert result[0][0] == f
+
+    def test_gs_file_routes_through_temp_js(self, tmp_path: Path) -> None:
+        """check_syntax() must use _check_via_temp_js for .gs files."""
+        f = _write(tmp_path, 'a.gs', 'var x = 1;\n')
+        with patch('pre_commit_hooks.js_syntax_check._check_via_temp_js', return_value=[]) as mock_fn:
+            from pre_commit_hooks.js_syntax_check import check_syntax
+            check_syntax(f)
+        mock_fn.assert_called_once_with(f)
+


### PR DESCRIPTION
## Problem

Node.js 24 raises `ERR_UNKNOWN_FILE_EXTENSION` when running `node --check file.gs`. Node.js 24 upgraded to ES module resolution by default and does not recognise `.gs` as a known extension.

## Fix

Added `_check_via_temp_js()`: copy `.gs` content to a temporary `.js` file, check that file, then replace the temp filename in any error messages so the output still points to the original `.gs` file.

## Tests

Added `TestCheckViaTempJs` covering clean, error, and routing cases.

Closes #56