### PR TITLE
feat(hooks): extend console-debug/log/table detection to TypeScript files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,29 +9,29 @@
   name: format dockerfiles
   types: ["dockerfile"]
 - id: console-debug-detection
-  description: detect console.debug() calls in JavaScript/AppScript files
+  description: detect console.debug() calls in JavaScript/TypeScript/AppScript files
   entry: console-debug-detection
-  files: \.(js|gs)$
+  files: \.(js|gs|ts|tsx)$
   language: python
   minimum_pre_commit_version: '4.1.0'
-  name: detect console.debug on javascript/appscript code
-  types_or: ["javascript", "file"]
+  name: detect console.debug on javascript/typescript/appscript code
+  types_or: ["javascript", "ts", "tsx", "file"]
 - id: console-log-detection
-  description: detect console.log() calls in JavaScript/AppScript files
+  description: detect console.log() calls in JavaScript/TypeScript/AppScript files
   entry: console-log-detection
-  files: \.(js|gs)$
+  files: \.(js|gs|ts|tsx)$
   language: python
   minimum_pre_commit_version: '4.1.0'
-  name: detect console.log on javascript/appscript code
-  types_or: ["javascript", "file"]
+  name: detect console.log on javascript/typescript/appscript code
+  types_or: ["javascript", "ts", "tsx", "file"]
 - id: console-table-detection
-  description: detect console.table() calls in JavaScript/AppScript files
+  description: detect console.table() calls in JavaScript/TypeScript/AppScript files
   entry: console-table-detection
-  files: \.(js|gs)$
+  files: \.(js|gs|ts|tsx)$
   language: python
   minimum_pre_commit_version: '4.1.0'
-  name: detect console.table on javascript/appscript code
-  types_or: ["javascript", "file"]
+  name: detect console.table on javascript/typescript/appscript code
+  types_or: ["javascript", "ts", "tsx", "file"]
 - id: python-print-detection
   description: detect print() calls in Python files
   entry: print-detection


### PR DESCRIPTION
## Change

Extend `console-debug-detection`, `console-log-detection`, and `console-table-detection` hooks to also run on `.ts` and `.tsx` files.

`no-console-warn` already covered TypeScript (`\.(js|gs|ts|jsx|tsx)$`) — this aligns the other three console hooks with the same coverage.

## Updated hooks
- `files`: `\.(js|gs)$` → `\.(js|gs|ts|tsx)$`
- `types_or`: added `"ts"` and `"tsx"`
- `description` / `name`: updated to mention TypeScript

Closes #51