### PR TITLE
chore(release): bump version to 0.0.34

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pre_commit_hooks_tools
-version = 0.0.33
+version = 0.0.34
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/chrysa/pre-commit-tools


### PR DESCRIPTION
## Release v0.0.34

Bump `version` in `setup.cfg` from `0.0.33` to `0.0.34` to allow consumers to pin by version in their `.pre-commit-config.yaml`:

```yaml
- repo: https://github.com/chrysa/pre-commit-tools
  rev: v0.0.34
  hooks: ...
```

After merge, create the corresponding git tag `v0.0.34`.

Closes #54