### PR TITLE
chore: regenerate detect-secrets baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -277,7 +277,30 @@
         "is_verified": false,
         "line_number": 50
       }
+    ],
+    "tests/test_ts_hardcoded_secret.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_ts_hardcoded_secret.py",
+        "hashed_secret": "84331946e55ba6fb22e85447668cc6f14a63dbd0",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_ts_hardcoded_secret.py",
+        "hashed_secret": "84331946e55ba6fb22e85447668cc6f14a63dbd0",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_ts_hardcoded_secret.py",
+        "hashed_secret": "b2f5657930768b15b8b7432e05fc631d4ea7f262",
+        "is_verified": false,
+        "line_number": 35
+      }
     ]
   },
-  "generated_at": "2026-03-31T16:46:09Z"
+  "generated_at": "2026-03-31T20:37:37Z"
 }


### PR DESCRIPTION
Regenerate `.secrets.baseline` to include fake test values from `tests/test_ts_hardcoded_secret.py` (AWS key, GitHub token, Stripe key placeholders). This fixes the `detect-secrets` pre-commit hook failing on CI.