### PR TITLE
chore: add dependencies-action, PR labeler, and CI standards

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,39 @@
+# Auto-labeling rules for pull requests
+# See: https://github.com/actions/labeler
+
+ci:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '.github/workflows/**'
+                - '.github/dependabot.yml'
+
+pre-commit:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '.pre-commit-config.yaml'
+                - '.pre-commit-hooks.yaml'
+
+documentation:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '*.md'
+                - 'docs/**'
+                - 'README*'
+
+dependencies:
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'pyproject.toml'
+                - 'requirements*.txt'
+                - 'package.json'
+                - 'package-lock.json'
+
+configuration:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '*.toml'
+                - '*.yml'
+                - '*.yaml'
+                - '*.json'
+                - '.env*'
+                - 'Makefile'

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,35 @@
+---
+name: PR Dependency Check
+
+on:
+    pull_request_target:
+        types: [closed, edited, opened, reopened]
+
+permissions:
+    issues: write
+    pull-requests: write
+
+jobs:
+    check_dependencies:
+        runs-on: ubuntu-latest
+        name: Check PR dependencies
+
+        steps:
+            - name: Check dependencies
+              uses: gregsdennis/dependencies-action@main
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Add dependent label
+              if: >-
+                  contains(github.event.pull_request.body, 'depends on') ||
+                  contains(github.event.pull_request.body, 'blocked by')
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      await github.rest.issues.addLabels({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.payload.pull_request.number,
+                        labels: ['dependent'],
+                      });

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+---
+name: PR Labeler
+
+on:
+    pull_request_target:
+        types: [opened, reopened, synchronize]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    labeler:
+        runs-on: ubuntu-latest
+        name: Label PR
+
+        steps:
+            - uses: actions/labeler@v5
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Standardization pass: add `gregsdennis/dependencies-action`, `actions/labeler`, and governance files.

## Changes

- `.github/workflows/dependencies.yml` — PR dependency check via `gregsdennis/dependencies-action@main`
- `.github/workflows/labeler.yml` — automatic PR labeling via `actions/labeler@v5`
- `.github/labeler.yml` — labeling rules (ci, pre-commit, documentation, dependencies, configuration)

## Why

Part of the chrysa ecosystem standardization effort.
All active repos should have consistent PR governance tooling.

## Related

- Depends on: chrysa/notion-automation#37 (pattern reference)
