### PR TITLE
feat: absorb generate-changelog hook from archived pre-commit-hooks-changelog

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -272,3 +272,11 @@
   minimum_pre_commit_version: '4.1.0'
   name: helm lint (charts/)
   pass_filenames: false
+- id: generate-changelog
+  description: generate CHANGELOG.md from git history using git-cliff (requires git-cliff in PATH)
+  entry: generate-changelog
+  language: python
+  minimum_pre_commit_version: '4.1.0'
+  name: generate changelog
+  pass_filenames: false
+  stages: [manual]

--- a/pre_commit_hooks/generate_changelog.py
+++ b/pre_commit_hooks/generate_changelog.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from typing import Optional, Sequence
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate CHANGELOG.md using git-cliff.",
+    )
+    parser.add_argument(
+        "--output",
+        default="CHANGELOG.md",
+        dest="output",
+        help="Path to the output changelog file (default: CHANGELOG.md)",
+    )
+    parser.add_argument(
+        "--tag",
+        default=None,
+        dest="tag",
+        help="Tag to use for the release (optional)",
+    )
+    parser.add_argument(
+        "--unreleased",
+        action="store_true",
+        dest="unreleased",
+        help="Only include unreleased commits",
+    )
+    parser.add_argument("filenames", nargs="*")
+    args = parser.parse_args(argv)
+
+    cmd = ["git", "cliff", "--output", args.output]
+    if args.tag:
+        cmd.extend(["--tag", args.tag])
+    if args.unreleased:
+        cmd.append("--unreleased")
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr)
+        return result.returncode
+
+    print(f"Changelog written to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ console_scripts =
     fastapi-missing-response-model = pre_commit_hooks.fastapi_missing_response_model:main
     js-syntax-check = pre_commit_hooks.js_syntax_check:main
     ts-hardcoded-secret-detection = pre_commit_hooks.ts_hardcoded_secret:main
+    generate-changelog = pre_commit_hooks.generate_changelog:main
 
 [options.extras_require]
 dead_code =

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -1,0 +1,73 @@
+"""Tests for generate_changelog hook."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pre_commit_hooks.generate_changelog import main
+
+
+class TestGenerateChangelog:
+    def test_success(self) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+        with patch("pre_commit_hooks.generate_changelog.subprocess.run", return_value=mock_result) as mock_run:
+            ret = main([])
+        assert ret == 0
+        mock_run.assert_called_once_with(
+            ["git", "cliff", "--output", "CHANGELOG.md"],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_custom_output(self) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+        with patch("pre_commit_hooks.generate_changelog.subprocess.run", return_value=mock_result) as mock_run:
+            ret = main(["--output", "docs/CHANGELOG.md"])
+        assert ret == 0
+        mock_run.assert_called_once_with(
+            ["git", "cliff", "--output", "docs/CHANGELOG.md"],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_with_tag(self) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+        with patch("pre_commit_hooks.generate_changelog.subprocess.run", return_value=mock_result) as mock_run:
+            ret = main(["--tag", "v1.2.3"])
+        assert ret == 0
+        mock_run.assert_called_once_with(
+            ["git", "cliff", "--output", "CHANGELOG.md", "--tag", "v1.2.3"],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_unreleased_flag(self) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+        with patch("pre_commit_hooks.generate_changelog.subprocess.run", return_value=mock_result) as mock_run:
+            ret = main(["--unreleased"])
+        assert ret == 0
+        mock_run.assert_called_once_with(
+            ["git", "cliff", "--output", "CHANGELOG.md", "--unreleased"],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_git_cliff_failure(self, capsys: pytest.CaptureFixture[str]) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "error: git-cliff failed\n"
+        with patch("pre_commit_hooks.generate_changelog.subprocess.run", return_value=mock_result):
+            ret = main([])
+        assert ret == 1
+        captured = capsys.readouterr()
+        assert "error: git-cliff failed" in captured.err


### PR DESCRIPTION
## Summary

Migrates the `generate-changelog` hook from the archived `chrysa/pre-commit-hooks-changelog` repo into `pre-commit-tools`.

## Changes

- **`pre_commit_hooks/generate_changelog.py`** — Python wrapper calling `git cliff` to generate `CHANGELOG.md` from git history
- **`.pre-commit-hooks.yaml`** — new `generate-changelog` hook entry (`stages: [manual]`)
- **`setup.cfg`** — new `generate-changelog` console script entry point
- **`tests/test_generate_changelog.py`** — 5 unit tests covering success, custom output, tag, unreleased, and failure cases

## Usage in consumer repos

```yaml
- repo: https://github.com/chrysa/pre-commit-tools
  rev: <version>
  hooks:
    - id: generate-changelog
      stages: [manual]
```

## Closes

- #101

## Dependents

- chrysa/container-webview — can now replace archived repo reference