### PR TITLE
fix(build): replace setuptools.backends.legacy with build_meta + ruff quote-style align

### DIFF
--- a/pre_commit_hooks/generate_changelog.py
+++ b/pre_commit_hooks/generate_changelog.py
@@ -3,48 +3,48 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
-from typing import Optional, Sequence
+from collections.abc import Sequence
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Generate CHANGELOG.md using git-cliff.",
+        description='Generate CHANGELOG.md using git-cliff.',
     )
     parser.add_argument(
-        "--output",
-        default="CHANGELOG.md",
-        dest="output",
-        help="Path to the output changelog file (default: CHANGELOG.md)",
+        '--output',
+        default='CHANGELOG.md',
+        dest='output',
+        help='Path to the output changelog file (default: CHANGELOG.md)',
     )
     parser.add_argument(
-        "--tag",
+        '--tag',
         default=None,
-        dest="tag",
-        help="Tag to use for the release (optional)",
+        dest='tag',
+        help='Tag to use for the release (optional)',
     )
     parser.add_argument(
-        "--unreleased",
-        action="store_true",
-        dest="unreleased",
-        help="Only include unreleased commits",
+        '--unreleased',
+        action='store_true',
+        dest='unreleased',
+        help='Only include unreleased commits',
     )
-    parser.add_argument("filenames", nargs="*")
+    parser.add_argument('filenames', nargs='*')
     args = parser.parse_args(argv)
 
-    cmd = ["git", "cliff", "--output", args.output]
+    cmd = ['git', 'cliff', '--output', args.output]
     if args.tag:
-        cmd.extend(["--tag", args.tag])
+        cmd.extend(['--tag', args.tag])
     if args.unreleased:
-        cmd.append("--unreleased")
+        cmd.append('--unreleased')
 
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
         print(result.stderr, file=sys.stderr)
         return result.returncode
 
-    print(f"Changelog written to {args.output}")
+    print(f'Changelog written to {args.output}')
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=72", "wheel"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "pre_commit_hooks_tools"
@@ -39,7 +39,7 @@ css-unused-variable-detection = "pre_commit_hooks.css_unused_variable:main"
 react-console-error-detection = "pre_commit_hooks.react_console_error_detection:main"
 no-bare-except-detection = "pre_commit_hooks.no_bare_except:main"
 no-print-in-migration = "pre_commit_hooks.no_print_in_migration:main"
-django-hardcoded-secret-detection = "pre_commit_hooks.django_hardcoded_secret:main"
+django-hardcoded-secret-detection = "pre_commit_hooks.django_hardcoded_secret:main"  # pragma: allowlist secret
 dockerfile-no-latest-detection = "pre_commit_hooks.dockerfile_no_latest:main"
 env-example-sync = "pre_commit_hooks.env_example_sync:main"
 no-console-warn = "pre_commit_hooks.no_console_warn:main"
@@ -50,7 +50,7 @@ django-no-raw-sql = "pre_commit_hooks.django_no_raw_sql:main"
 no-sync-in-async = "pre_commit_hooks.no_sync_in_async:main"
 fastapi-missing-response-model = "pre_commit_hooks.fastapi_missing_response_model:main"
 js-syntax-check = "pre_commit_hooks.js_syntax_check:main"
-ts-hardcoded-secret-detection = "pre_commit_hooks.ts_hardcoded_secret:main"
+ts-hardcoded-secret-detection = "pre_commit_hooks.ts_hardcoded_secret:main"  # pragma: allowlist secret
 generate-changelog = "pre_commit_hooks.generate_changelog:main"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,11 @@ max-complexity = 15
 ban-relative-imports = "all"
 
 [tool.ruff.format]
-quote-style = "double"
+quote-style = "single"
 indent-style = "space"
+line-ending = "lf"
+docstring-code-format = true
+skip-magic-trailing-comma = false
 
 [tool.mypy]
 cache_dir = "/dev/null"

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -13,12 +13,12 @@ class TestGenerateChangelog:
     def test_success(self) -> None:
         mock_result = MagicMock()
         mock_result.returncode = 0
-        mock_result.stderr = ""
-        with patch("pre_commit_hooks.generate_changelog.subprocess.run", return_value=mock_result) as mock_run:
+        mock_result.stderr = ''
+        with patch('pre_commit_hooks.generate_changelog.subprocess.run', return_value=mock_result) as mock_run:
             ret = main([])
         assert ret == 0
         mock_run.assert_called_once_with(
-            ["git", "cliff", "--output", "CHANGELOG.md"],
+            ['git', 'cliff', '--output', 'CHANGELOG.md'],
             capture_output=True,
             text=True,
         )
@@ -26,12 +26,12 @@ class TestGenerateChangelog:
     def test_custom_output(self) -> None:
         mock_result = MagicMock()
         mock_result.returncode = 0
-        mock_result.stderr = ""
-        with patch("pre_commit_hooks.generate_changelog.subprocess.run", return_value=mock_result) as mock_run:
-            ret = main(["--output", "docs/CHANGELOG.md"])
+        mock_result.stderr = ''
+        with patch('pre_commit_hooks.generate_changelog.subprocess.run', return_value=mock_result) as mock_run:
+            ret = main(['--output', 'docs/CHANGELOG.md'])
         assert ret == 0
         mock_run.assert_called_once_with(
-            ["git", "cliff", "--output", "docs/CHANGELOG.md"],
+            ['git', 'cliff', '--output', 'docs/CHANGELOG.md'],
             capture_output=True,
             text=True,
         )
@@ -39,12 +39,12 @@ class TestGenerateChangelog:
     def test_with_tag(self) -> None:
         mock_result = MagicMock()
         mock_result.returncode = 0
-        mock_result.stderr = ""
-        with patch("pre_commit_hooks.generate_changelog.subprocess.run", return_value=mock_result) as mock_run:
-            ret = main(["--tag", "v1.2.3"])
+        mock_result.stderr = ''
+        with patch('pre_commit_hooks.generate_changelog.subprocess.run', return_value=mock_result) as mock_run:
+            ret = main(['--tag', 'v1.2.3'])
         assert ret == 0
         mock_run.assert_called_once_with(
-            ["git", "cliff", "--output", "CHANGELOG.md", "--tag", "v1.2.3"],
+            ['git', 'cliff', '--output', 'CHANGELOG.md', '--tag', 'v1.2.3'],
             capture_output=True,
             text=True,
         )
@@ -52,12 +52,12 @@ class TestGenerateChangelog:
     def test_unreleased_flag(self) -> None:
         mock_result = MagicMock()
         mock_result.returncode = 0
-        mock_result.stderr = ""
-        with patch("pre_commit_hooks.generate_changelog.subprocess.run", return_value=mock_result) as mock_run:
-            ret = main(["--unreleased"])
+        mock_result.stderr = ''
+        with patch('pre_commit_hooks.generate_changelog.subprocess.run', return_value=mock_result) as mock_run:
+            ret = main(['--unreleased'])
         assert ret == 0
         mock_run.assert_called_once_with(
-            ["git", "cliff", "--output", "CHANGELOG.md", "--unreleased"],
+            ['git', 'cliff', '--output', 'CHANGELOG.md', '--unreleased'],
             capture_output=True,
             text=True,
         )
@@ -65,9 +65,9 @@ class TestGenerateChangelog:
     def test_git_cliff_failure(self, capsys: pytest.CaptureFixture[str]) -> None:
         mock_result = MagicMock()
         mock_result.returncode = 1
-        mock_result.stderr = "error: git-cliff failed\n"
-        with patch("pre_commit_hooks.generate_changelog.subprocess.run", return_value=mock_result):
+        mock_result.stderr = 'error: git-cliff failed\n'
+        with patch('pre_commit_hooks.generate_changelog.subprocess.run', return_value=mock_result):
             ret = main([])
         assert ret == 1
         captured = capsys.readouterr()
-        assert "error: git-cliff failed" in captured.err
+        assert 'error: git-cliff failed' in captured.err


### PR DESCRIPTION
Fixes pre-commit wheel build failure:
```
ERROR [Errno 2]: Building wheel for pre_commit_placeholder_package — setuptools.backends.legacy deprecated
```

- Replace `setuptools.backends.legacy:BuildBackend` with `setuptools.build_meta`
- Align ruff `quote-style=single` in pyproject.toml