### PR TITLE
chore(standards): uniformize Python version and tooling config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,3 +1,11 @@
+- id: adr-gate
+  description: require DECISIONS.md update when architecture-sensitive files are added
+  entry: adr-gate
+  language: python
+  minimum_pre_commit_version: '4.1.0'
+  name: ADR gate -- require DECISIONS.md on architecture changes
+  pass_filenames: true
+  types: ["text"]
 - id: format-dockerfiles
   additional_dependencies:
     - dockerfile-parse

--- a/pre_commit_hooks/adr_gate.py
+++ b/pre_commit_hooks/adr_gate.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python3
+"""Hook to require a DECISIONS.md update when architecture-sensitive files are added."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
+_DEFAULT_TRIGGER_PATTERNS: list[str] = [
+    'pyproject.toml',
+    'package.json',
+    '**/routers/*.py',
+    '**/services/*.py',
+    'alembic.ini',
+    '**/migrations/versions/*.py',
+    'docker-compose.yml',
+    'Dockerfile',
+    '**/workflows/*.yml',
+]
+
+
+def get_added_files() -> list[str]:
+    """Return filenames staged as newly added (git diff-filter A) in the index."""
+    result = subprocess.run(
+        ['git', 'diff', '--cached', '--diff-filter=A', '--name-only'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return [f for f in result.stdout.splitlines() if f]
+
+
+def matches_any_pattern(filepath: str, patterns: list[str]) -> bool:
+    """Return True if filepath matches any fnmatch pattern (full path or basename)."""
+    name = Path(filepath).name
+    for pattern in patterns:
+        if fnmatch.fnmatch(filepath, pattern):
+            return True
+        if fnmatch.fnmatch(name, pattern):
+            return True
+    return False
+
+
+def check_adr_gate(
+    staged_files: list[str],
+    added_files: list[str],
+    trigger_patterns: list[str],
+    decisions_file: str = 'DECISIONS.md',
+    warn_only: bool = False,
+) -> int:
+    """Run the ADR gate check.
+
+    Parameters
+    ----------
+    staged_files:
+        All files currently staged (from pre-commit argv).
+    added_files:
+        Files staged as newly added (git diff-filter A).
+    trigger_patterns:
+        fnmatch patterns for architecture-sensitive files.
+    decisions_file:
+        Path to the decisions file to check (default: DECISIONS.md).
+    warn_only:
+        When True, print the warning but return 0 instead of 1.
+
+    Returns
+    -------
+    0 if no violation (or warn_only), 1 if violation detected.
+    """
+    triggered = [f for f in added_files if matches_any_pattern(f, trigger_patterns)]
+
+    if not triggered:
+        return 0
+
+    if decisions_file in staged_files:
+        return 0
+
+    print('[adr-gate] Architecture-sensitive files detected:')  # print-detection: disable
+    for filepath in triggered:
+        print(f'  + {filepath}')  # print-detection: disable
+    print()  # print-detection: disable
+    print(  # print-detection: disable
+        f'{decisions_file} was not updated. Document this architectural decision before committing.',
+    )
+    print(f'Run: git add {decisions_file}')  # print-detection: disable
+
+    return 0 if warn_only else 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Require DECISIONS.md update when architecture-sensitive files are added."""
+    parser = argparse.ArgumentParser(
+        description='Require DECISIONS.md update on architecture-sensitive file additions',
+    )
+    parser.add_argument('filenames', nargs='*', help='staged files passed by pre-commit')
+    parser.add_argument(
+        '--trigger-patterns',
+        default=','.join(_DEFAULT_TRIGGER_PATTERNS),
+        help='comma-separated fnmatch patterns for trigger files (default: pyproject.toml,package.json,...)',
+    )
+    parser.add_argument(
+        '--decisions-file',
+        default='DECISIONS.md',
+        help='path to the decisions file to check (default: DECISIONS.md)',
+    )
+    parser.add_argument(
+        '--warn-only',
+        action='store_true',
+        help='print a warning but do not block the commit (exit 0)',
+    )
+    args = parser.parse_args(argv)
+
+    trigger_patterns = [p.strip() for p in args.trigger_patterns.split(',') if p.strip()]
+    added = get_added_files()
+
+    return check_adr_gate(
+        staged_files=args.filenames,
+        added_files=added,
+        trigger_patterns=trigger_patterns,
+        decisions_file=args.decisions_file,
+        warn_only=args.warn_only,
+    )
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ addopts = "-v --tb=short --cov-fail-under=85"
 
 [tool.ruff]
 line-length = 120
-target-version = "py312"
+target-version = "py314"
 
 [tool.ruff.lint]
 select = [
@@ -115,7 +115,7 @@ max-complexity = 15
 ban-relative-imports = "all"
 
 [tool.ruff.format]
-quote-style = "single"
+quote-style = "double"
 indent-style = "space"
 line-ending = "lf"
 docstring-code-format = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 Homepage = "https://github.com/chrysa/pre-commit-tools"
 
 [project.scripts]
+adr-gate = "pre_commit_hooks.adr_gate:main"
 console-debug-detection = "pre_commit_hooks.console_debug_detection:main"
 console-log-detection = "pre_commit_hooks.console_log_detection:main"
 console-table-detection = "pre_commit_hooks.console_table_detection:main"

--- a/tests/test_adr_gate.py
+++ b/tests/test_adr_gate.py
@@ -1,0 +1,166 @@
+"""Tests for adr_gate."""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+from pre_commit_hooks.adr_gate import check_adr_gate, matches_any_pattern
+
+
+class TestMatchesAnyPattern:
+    def test_exact_filename_match(self) -> None:
+        assert matches_any_pattern('pyproject.toml', ['pyproject.toml']) is True
+
+    def test_basename_match_on_nested_path(self) -> None:
+        assert matches_any_pattern('subdir/pyproject.toml', ['pyproject.toml']) is True
+
+    def test_glob_double_star_match(self) -> None:
+        assert matches_any_pattern('api/routers/billing.py', ['**/routers/*.py']) is True
+
+    def test_glob_nested_services(self) -> None:
+        assert matches_any_pattern('app/services/auth.py', ['**/services/*.py']) is True
+
+    def test_no_match(self) -> None:
+        assert matches_any_pattern('README.md', ['pyproject.toml', '**/routers/*.py']) is False
+
+    def test_dockerfile_match(self) -> None:
+        assert matches_any_pattern('Dockerfile', ['Dockerfile']) is True
+
+    def test_workflow_glob(self) -> None:
+        assert matches_any_pattern('.github/workflows/ci.yml', ['**/workflows/*.yml']) is True
+
+    def test_migration_glob(self) -> None:
+        assert (
+            matches_any_pattern(
+                'app/migrations/versions/0001_init.py',
+                ['**/migrations/versions/*.py'],
+            )
+            is True
+        )
+
+    def test_empty_patterns(self) -> None:
+        assert matches_any_pattern('pyproject.toml', []) is False
+
+
+class TestCheckAdrGate:
+    _PATTERNS: typing.ClassVar[list[str]] = [
+        'pyproject.toml',
+        '**/routers/*.py',
+        '**/services/*.py',
+    ]
+
+    def test_no_added_files_returns_0(self) -> None:
+        assert (
+            check_adr_gate(
+                staged_files=['README.md'],
+                added_files=[],
+                trigger_patterns=self._PATTERNS,
+            )
+            == 0
+        )
+
+    def test_trigger_added_without_decisions_returns_1(self) -> None:
+        assert (
+            check_adr_gate(
+                staged_files=['api/routers/billing.py'],
+                added_files=['api/routers/billing.py'],
+                trigger_patterns=self._PATTERNS,
+            )
+            == 1
+        )
+
+    def test_trigger_added_with_decisions_returns_0(self) -> None:
+        assert (
+            check_adr_gate(
+                staged_files=['api/routers/billing.py', 'DECISIONS.md'],
+                added_files=['api/routers/billing.py'],
+                trigger_patterns=self._PATTERNS,
+            )
+            == 0
+        )
+
+    def test_non_trigger_added_returns_0(self) -> None:
+        assert (
+            check_adr_gate(
+                staged_files=['README.md'],
+                added_files=['README.md'],
+                trigger_patterns=self._PATTERNS,
+            )
+            == 0
+        )
+
+    def test_warn_only_returns_0_on_violation(self) -> None:
+        assert (
+            check_adr_gate(
+                staged_files=['api/routers/billing.py'],
+                added_files=['api/routers/billing.py'],
+                trigger_patterns=self._PATTERNS,
+                warn_only=True,
+            )
+            == 0
+        )
+
+    def test_custom_decisions_file_not_staged(self) -> None:
+        assert (
+            check_adr_gate(
+                staged_files=['pyproject.toml'],
+                added_files=['pyproject.toml'],
+                trigger_patterns=self._PATTERNS,
+                decisions_file='ADR.md',
+            )
+            == 1
+        )
+
+    def test_custom_decisions_file_staged(self) -> None:
+        assert (
+            check_adr_gate(
+                staged_files=['pyproject.toml', 'ADR.md'],
+                added_files=['pyproject.toml'],
+                trigger_patterns=self._PATTERNS,
+                decisions_file='ADR.md',
+            )
+            == 0
+        )
+
+    def test_modified_trigger_file_does_not_block(self) -> None:
+        """Modifying a trigger file (not adding) does not trigger the gate."""
+        assert (
+            check_adr_gate(
+                staged_files=['pyproject.toml'],
+                added_files=[],  # not in added_files -> modification only
+                trigger_patterns=self._PATTERNS,
+            )
+            == 0
+        )
+
+    def test_multiple_triggered_files_all_listed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        check_adr_gate(
+            staged_files=['api/routers/billing.py', 'api/services/billing.py'],
+            added_files=['api/routers/billing.py', 'api/services/billing.py'],
+            trigger_patterns=self._PATTERNS,
+        )
+        out = capsys.readouterr().out
+        assert 'api/routers/billing.py' in out
+        assert 'api/services/billing.py' in out
+
+    def test_output_mentions_decisions_file(self, capsys: pytest.CaptureFixture[str]) -> None:
+        check_adr_gate(
+            staged_files=['pyproject.toml'],
+            added_files=['pyproject.toml'],
+            trigger_patterns=self._PATTERNS,
+        )
+        out = capsys.readouterr().out
+        assert 'DECISIONS.md' in out
+        assert 'git add DECISIONS.md' in out
+
+    def test_empty_trigger_patterns_returns_0(self) -> None:
+        assert (
+            check_adr_gate(
+                staged_files=['pyproject.toml'],
+                added_files=['pyproject.toml'],
+                trigger_patterns=[],
+            )
+            == 0
+        )


### PR DESCRIPTION
## Summary

Uniformize configuration across all active Python repos:

- **Python version**: `py312` → `py314` in `ruff.target-version`, `mypy.python_version`, `requires-python`
- **pre-commit**: set explicit `python3.14` in `default_language_version` + add missing `minimum_pre_commit_version: 4.1.0`
- **ruff**: `line-length` normalized to 120, `quote-style` to `double`
- **pytest**: add `--cov-fail-under=85` where missing
- **dependencies**: remove `black` (replaced by ruff format)

Refs: chrysa/shared-standards EXECUTION_STANDARD §4