### PR TITLE
chore(standards): bump requires-python to >=3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.34"
 description = "Pre-commit hooks collection for chrysa projects"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "MIT" }
-requires-python = ">=3.12"
+requires-python = ">=3.14"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Align requires-python with ecosystem standard (Python 3.14).