### PR TITLE
fix(quality): fix CI quality gates (gitleaks, mypy, ruff format, py314)

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -21,7 +21,7 @@ jobs:
               with:
                   fetch-depth: 0
             - name: SonarCloud scan
-              uses: SonarSource/sonarqube-scan-action@v8
+              uses: SonarSource/sonarqube-scan-action@v8.0.0
               with:
                   args: >
                       -Dsonar.projectKey=chrysa_pre-commit-tools

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,8 +3,9 @@ title = "Gitleaks configuration for pre-commit-tools"
 [extend]
 useDefault = true
 
-[[allowlists]]
+[allowlist]
 description = "Ignore detect-secrets baseline files — hashed_secret SHA1 values are not real secrets"
 paths = [
     '''.secrets\.baseline''',
+    '''secrets\.baseline''',
 ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,55 +146,63 @@ repos:
         entry: print-detection
         language: python
         types: [python]
+        additional_dependencies: ["."]
       - id: python-pprint-detection
         name: detect pprint on python code
         entry: pprint-detection
         language: python
         types: [python]
+        additional_dependencies: ["."]
       - id: debugger-detection
         name: detect debugger statements
         entry: debugger-detection
         language: python
+        additional_dependencies: ["."]
       - id: yaml-sorter
         exclude: '^(\.github/|GitVersion\.yml)'
         name: sort yaml files
         entry: yaml-sorter
         language: python
         types: [yaml]
-        additional_dependencies: [PyYAML]
+        additional_dependencies: [".[yaml]"]
       - id: json-sorter
         name: sort json files
         entry: json-sorter
         language: python
         types: [json]
+        additional_dependencies: ["."]
       - id: requirements-sort
         name: sort requirements files
         entry: requirements-sort
         language: python
         types: [text]
         files: requirements.*\.txt$
+        additional_dependencies: ["."]
       - id: env-file-check
         name: check env files for secrets
         entry: env-file-check
         language: python
         types: [text]
         files: \.env
+        additional_dependencies: ["."]
       - id: python-logger-detection
         name: detect root logger usage
         entry: logger-detection
         language: python
         types: [python]
+        additional_dependencies: ["."]
       - id: python-unreachable-code
         name: detect unreachable code
         entry: unreachable-code-detection
         language: python
         types: [python]
+        additional_dependencies: ["."]
       - id: python-dead-code
         name: detect dead/unused code
         entry: dead-code-detection
         language: python
         types: [python]
-        additional_dependencies: [vulture>=2.0]
+        additional_dependencies: [".[dead_code]"]
         stages: [manual]
 
   - repo: https://github.com/gitleaks/gitleaks

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -12,5 +12,5 @@ FROM deps AS test
 COPY . .
 
 CMD ["pytest", "--cov=pre_commit_hooks", "--cov-branch", \
-     "--cov-report=xml:reports/coverage.xml", \
-     "--cov-report=term-missing"]
+    "--cov-report=xml:reports/coverage.xml", \
+    "--cov-report=term-missing"]

--- a/config-tools/ruff.toml
+++ b/config-tools/ruff.toml
@@ -17,10 +17,10 @@ select = [
     "RUF",  # ruff-specific rules
 ]
 ignore = [
-    "E203",   # whitespace before ':' (conflicts with black-style formatting)
-    "S101",   # assert used (fine in tests)
-    "S603",   # subprocess call: check=False (too noisy for hook scripts)
-    "S607",   # starting a process with a partial executable path
+    "E203", # whitespace before ':' (conflicts with black-style formatting)
+    "S101", # assert used (fine in tests)
+    "S603", # subprocess call: check=False (too noisy for hook scripts)
+    "S607", # starting a process with a partial executable path
 ]
 
 [lint.mccabe]

--- a/config-tools/ruff.toml
+++ b/config-tools/ruff.toml
@@ -1,5 +1,5 @@
 line-length = 120
-target-version = "py312"
+target-version = "py314"
 
 [lint]
 select = [

--- a/pre_commit_hooks/css_unused_variable.py
+++ b/pre_commit_hooks/css_unused_variable.py
@@ -63,7 +63,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for filename in args.filenames:
         try:
             source = Path(filename).read_text(encoding='utf-8')
-        except (OSError, UnicodeDecodeError):
+        except OSError, UnicodeDecodeError:
             continue
         for fname, lineno, msg in detect_unused_variables(source, filename):
             print(f'{fname}:{lineno}: {msg}')  # print-detection: disable

--- a/pre_commit_hooks/django_hardcoded_secret.py
+++ b/pre_commit_hooks/django_hardcoded_secret.py
@@ -75,7 +75,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for filename in args.filenames:
         try:
             source = Path(filename).read_text(encoding='utf-8')
-        except (OSError, UnicodeDecodeError):
+        except OSError, UnicodeDecodeError:
             continue
         for fname, lineno, msg in detect_hardcoded_secrets(source, filename):
             print(f'{fname}:{lineno}: {msg}')  # print-detection: disable

--- a/pre_commit_hooks/dockerfile_no_latest.py
+++ b/pre_commit_hooks/dockerfile_no_latest.py
@@ -42,7 +42,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             with open(filename, encoding='utf-8') as f:
                 source = f.read()
-        except (OSError, UnicodeDecodeError):
+        except OSError, UnicodeDecodeError:
             continue
         for fname, lineno, msg in detect_from_latest(source, filename):
             print(f'{fname}:{lineno}: {msg}')

--- a/pre_commit_hooks/env_example_sync.py
+++ b/pre_commit_hooks/env_example_sync.py
@@ -25,7 +25,7 @@ def _parse_keys(path: Path) -> set[str]:
                 m = _KEY_RE.match(line)
                 if m:
                     keys.add(m.group(1))
-    except (OSError, UnicodeDecodeError):
+    except OSError, UnicodeDecodeError:
         pass
     return keys
 

--- a/pre_commit_hooks/fastapi_missing_response_model.py
+++ b/pre_commit_hooks/fastapi_missing_response_model.py
@@ -76,7 +76,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for filename in args.filenames:
         try:
             source = Path(filename).read_text(encoding='utf-8')
-        except (OSError, UnicodeDecodeError):
+        except OSError, UnicodeDecodeError:
             continue
         for fname, lineno, msg in detect_missing_response_model(source, filename):
             print(f'{fname}:{lineno}: {msg}', file=sys.stderr)

--- a/pre_commit_hooks/format_dockerfile.py
+++ b/pre_commit_hooks/format_dockerfile.py
@@ -36,7 +36,7 @@ def _load_config(config_path: Path) -> dict[str, bool]:
     try:
         data = tomllib.loads(config_path.read_text(encoding='utf-8'))
         return data.get('format-dockerfiles', {})
-    except (OSError, tomllib.TOMLDecodeError):
+    except OSError, tomllib.TOMLDecodeError:
         return {}
 
 

--- a/pre_commit_hooks/js_syntax_check.py
+++ b/pre_commit_hooks/js_syntax_check.py
@@ -22,7 +22,7 @@ def _check_node_available() -> bool:
             capture_output=True,
             timeout=5,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except FileNotFoundError, subprocess.TimeoutExpired:
         return False
     else:
         return True

--- a/pre_commit_hooks/no_sync_in_async.py
+++ b/pre_commit_hooks/no_sync_in_async.py
@@ -105,7 +105,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for filename in args.filenames:
         try:
             source = Path(filename).read_text(encoding='utf-8')
-        except (OSError, UnicodeDecodeError):
+        except OSError, UnicodeDecodeError:
             continue
         for fname, lineno, msg in detect_sync_in_async(source, filename):
             print(f'{fname}:{lineno}: {msg}', file=sys.stderr)

--- a/pre_commit_hooks/regression_gate.py
+++ b/pre_commit_hooks/regression_gate.py
@@ -42,7 +42,7 @@ def _parse_coverage(report_path: Path) -> float | None:
         line_rate = tree.getroot().get('line-rate')
         if line_rate is not None:
             return round(float(line_rate) * 100, 2)
-    except (ElementTree.ParseError, ValueError, OSError):
+    except ElementTree.ParseError, ValueError, OSError:
         pass
     return None
 
@@ -73,7 +73,7 @@ def _parse_test_count(report_path: Path) -> int | None:
             1 for tc in root.iter('testcase') if not (tc.find('failure') is not None or tc.find('error') is not None)
         )
         return passed
-    except (ElementTree.ParseError, ValueError, OSError):
+    except ElementTree.ParseError, ValueError, OSError:
         pass
     return None
 
@@ -84,7 +84,7 @@ def _load_baseline(path: Path) -> dict | None:
         return None
     try:
         return json.loads(path.read_text(encoding='utf-8'))
-    except (json.JSONDecodeError, OSError):
+    except json.JSONDecodeError, OSError:
         return None
 
 

--- a/pre_commit_hooks/regression_gate.py
+++ b/pre_commit_hooks/regression_gate.py
@@ -78,7 +78,7 @@ def _parse_test_count(report_path: Path) -> int | None:
     return None
 
 
-def _load_baseline(path: Path) -> dict | None:  # type: ignore[type-arg]
+def _load_baseline(path: Path) -> dict | None:
     """Return the baseline dict, or ``None`` if the file does not exist."""
     if not path.exists():
         return None
@@ -110,7 +110,7 @@ def _write_baseline(
     tests_passed: int | None,
 ) -> None:
     """Persist current metrics as the new baseline."""
-    data: dict = {  # type: ignore[type-arg]
+    data: dict = {
         '_comment': 'Regression baseline — update with: make baseline',
         'updated_at': datetime.now(tz=UTC).isoformat(),
         'git_sha': _git_sha(),

--- a/pre_commit_hooks/ts_hardcoded_secret.py
+++ b/pre_commit_hooks/ts_hardcoded_secret.py
@@ -82,7 +82,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for filename in args.filenames:
         try:
             source = Path(filename).read_text(encoding='utf-8')
-        except (OSError, UnicodeDecodeError):
+        except OSError, UnicodeDecodeError:
             continue
         for fname, lineno, msg in detect_hardcoded_secrets(source, filename):
             print(f'{fname}:{lineno}: {msg}')  # print-detection: disable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ max-complexity = 15
 ban-relative-imports = "all"
 
 [tool.ruff.format]
-quote-style = "double"
+quote-style = "single"
 indent-style = "space"
 line-ending = "lf"
 docstring-code-format = true

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -108,7 +108,7 @@ class QualityGate:
         try:
             d = json.loads(output)
             return sum(len(v) for v in d.get('results', {}).values())
-        except (json.JSONDecodeError, AttributeError, ValueError):
+        except json.JSONDecodeError, AttributeError, ValueError:
             pass
         match = re.search(r'secrets?\s+found[:\s]+(\d+)', output, re.IGNORECASE)
         if match:


### PR DESCRIPTION
## Changes

- **Gitleaks**: fix `[[allowlists]]` → `[allowlist]` (Gitleaks v8 expects singular table key); add second path fallback
- **mypy**: remove two unused `# type: ignore[type-arg]` in `regression_gate.py` (dict directly subscriptable in Python 3.14)
- **ruff format**: align `config-tools/ruff.toml` (target-version py312→py314) and `pyproject.toml` (quote-style double→single) to fix pre-push hook
- Apply PEP 758 formatting to 11 files (`except A, B:` instead of `except (A, B):`)