### PR TITLE
ci(sonar): pin sonarqube-scan-action to v8.0.0

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -21,7 +21,7 @@ jobs:
               with:
                   fetch-depth: 0
             - name: SonarCloud scan
-              uses: SonarSource/sonarqube-scan-action@v8
+              uses: SonarSource/sonarqube-scan-action@v8.0.0
               with:
                   args: >
                       -Dsonar.projectKey=chrysa_pre-commit-tools


### PR DESCRIPTION
## Problem

`SonarSource/sonarqube-scan-action@v8` (latest major) introduced a regression post-v8.0.0:
- `ArchitectureConfigLoader` bean creation fails on multi-language projects
- Quality Gate exits with code 3 on Python-only projects
- 12+ repos with billing-blocked CI will face the same issue once billing is resolved

## Fix

Pin all `sonar.yml` workflows to `@v8.0.0` — the same version used by passing repos (`container-webview`, `project-init`, `epub-sorter`, `github-actions`).

## Verification

Repos using `@v8.0.0` have green Sonar: container-webview, project-init, epub-sorter, github-actions.