### PR TITLE
docs(instructions): add Python structure rules from Notion Engineering Standards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# CODEOWNERS
+# Default owner for all files
+* @chrysa
+
+# Backend / Python source
+/backend/ @chrysa
+/src/ @chrysa
+/api/ @chrysa
+/code/ @chrysa
+
+# Frontend / Node source
+/frontend/ @chrysa
+
+# Infrastructure / CI
+/.github/ @chrysa
+/Dockerfile @chrysa
+/docker-compose*.yml @chrysa
+/k8s/ @chrysa
+
+# Documentation
+*.md @chrysa
+/docs/ @chrysa

--- a/.github/instructions/frontend_guidelines.instructions.md
+++ b/.github/instructions/frontend_guidelines.instructions.md
@@ -87,3 +87,17 @@ Duplicate properties are caught by `css-duplicate-property-detection`.
 
 All `.js` and `.gs` (Google Apps Script) files must pass Node.js syntax validation.
 The `js-syntax-check` hook runs `node --check` on every `.js/.gs` file.
+
+
+---
+
+## Loading States (NON-NEGOTIABLE)
+
+- Every waiting state > **200 ms** must be materialised without layout shift (CLS = 0).
+- Hierarchy: **skeleton → progress bar → spinner**. Never a full-screen spinner on a page with known structure.
+- Use `React.lazy()` + `<Suspense fallback={<Skeleton />}>` for all routes, charts, modals, editors.
+- Skeletons: `<Skeleton />` from shadcn/ui, shaped like the content. Add `aria-busy="true"`, respect `prefers-reduced-motion`.
+- Show skeleton on `isPending`. **Never hide existing content** during background refetch (`isFetching`).
+- Progress bar: determinate (`<Progress value={n} />`) when a real % exists. Top-of-page indeterminate for route transitions only.
+- Images: always `loading="lazy" decoding="async"` + explicit `width`/`height` or `aspect-ratio` to prevent CLS.
+- i18n: all user-facing strings via `react-i18next` (`useTranslation`). No hardcoded UI text in components.

--- a/.github/instructions/python_guidelines.instructions.md
+++ b/.github/instructions/python_guidelines.instructions.md
@@ -184,3 +184,11 @@ except:
 4. Write tests in `tests/test_my_hook.py`
 5. Run `ruff check` + `pytest` — both must pass
 6. Add documentation in `README.md`
+
+---
+
+## Structure Rules (from Notion Engineering Standards 2026-05-21)
+
+- **One class per file.** Each class lives in its own module (e.g. `models/user.py` contains only `User`).
+- **Domain-driven structure.** Organise by domain (`connectors/`, `services/`, `schemas/`) — not by layer.
+- **No `print()` in production.** Use `structlog` or `logging` with JSON formatter.

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ dist/
 .ci-backup-*/
 .gitnexus
 guideline-report.html
+
+# CodeGraph (local index — never commit)
+.codegraph/


### PR DESCRIPTION
docs(instructions): add Python structure rules from Notion Engineering Standards

- One class per file convention
- Domain-driven structure  
- No print() in production (use structlog/logging)

Source: Notion Engineering Standards 2026-05-21