### PR TITLE
feat(hooks): detect duplicated copilot instructions + ci(install): migrate to install-project composite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@v6
-            - uses: actions/setup-python@v6
+            - uses: chrysa/github-actions/python-setup@v1
               with:
                   python-version: ${{ needs.config.outputs.latest-python }}
             - name: Install package for system hooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,9 @@ jobs:
             - uses: chrysa/github-actions/python-setup@v1
               with:
                   python-version: ${{ needs.config.outputs.latest-python }}
-            - name: Install package for system hooks
-              run: pip install -e '.[yaml,format_dockerfile,ts_unreachable_code]'
+            - uses: chrysa/github-actions/install-project@v1
+              with:
+                  extras: yaml,format_dockerfile,ts_unreachable_code
             - uses: pre-commit/action@v3.0.1
               env:
                   SKIP: no-commit-to-branch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -207,3 +207,9 @@ repos:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [feat, fix, docs, style, refactor, test, chore, perf, revert, ci]
+
+  - repo: https://github.com/chrysa/pre-commit-tools
+    rev: v0.1.1-76
+    hooks:
+      - id: regression-gate
+        stages: [pre-push]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,6 +6,15 @@
   name: ADR gate -- require DECISIONS.md on architecture changes
   pass_filenames: true
   types: ["text"]
+- id: detect-duplicated-copilot-instructions
+  description: detect sections in per-repo copilot-instructions.md already present in workspace-level instructions
+  entry: detect-duplicated-copilot-instructions
+  files: '\.github/copilot-instructions\.md$'
+  language: python
+  minimum_pre_commit_version: '4.1.0'
+  name: detect duplicated copilot-instructions sections
+  pass_filenames: true
+  types: [markdown]
 - id: format-dockerfiles
   additional_dependencies:
     - dockerfile-parse

--- a/pre_commit_hooks/copilot_instructions_duplication.py
+++ b/pre_commit_hooks/copilot_instructions_duplication.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python3
+"""Hook to detect sections in per-repo copilot-instructions.md already present in workspace instructions."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+from collections.abc import Sequence
+from pathlib import Path
+
+_DISABLE_COMMENT = 'detect-duplicated-copilot-instructions: disable'
+_DEFAULT_THRESHOLD = 0.80
+_INSTRUCTIONS_REL = Path('.github') / 'copilot-instructions.md'
+
+
+def extract_sections(text: str) -> dict[str, str]:
+    """Return {heading: body} for every H2 section (## Title) in *text*."""
+    sections: dict[str, str] = {}
+    current_heading: str | None = None
+    current_lines: list[str] = []
+
+    for line in text.splitlines(keepends=True):
+        if line.startswith('## '):
+            if current_heading is not None:
+                sections[current_heading] = ''.join(current_lines).strip()
+            current_heading = line.strip().lstrip('# ').strip()
+            current_lines = []
+        elif current_heading is not None:
+            current_lines.append(line)
+
+    if current_heading is not None:
+        sections[current_heading] = ''.join(current_lines).strip()
+
+    return sections
+
+
+def similarity(a: str, b: str) -> float:
+    """Return SequenceMatcher ratio between two strings."""
+    return difflib.SequenceMatcher(None, a, b).ratio()
+
+
+def find_workspace_instructions(repo_file: Path) -> Path | None:
+    """Walk up from *repo_file* to find the workspace-level copilot-instructions.md.
+
+    Returns the path if found above the repo's own .github/ directory, else None.
+    """
+    # The repo_file is e.g. /workspace/chrysa/some-repo/.github/copilot-instructions.md
+    # We walk up 3+ levels to find /workspace/.github/copilot-instructions.md
+    current = repo_file.resolve().parent.parent  # skip .github/ of the repo
+    while True:
+        candidate = current / _INSTRUCTIONS_REL
+        if candidate.exists() and candidate.resolve() != repo_file.resolve():
+            return candidate
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
+def check_duplications(
+    repo_file: Path,
+    workspace_file: Path,
+    threshold: float,
+) -> list[tuple[float, str]]:
+    """Return list of (ratio, heading) for sections duplicated above *threshold*."""
+    repo_text = repo_file.read_text(encoding='utf-8')
+
+    # Respect file-level disable comment
+    if _DISABLE_COMMENT in repo_text:
+        return []
+
+    repo_sections = extract_sections(repo_text)
+    workspace_sections = extract_sections(workspace_file.read_text(encoding='utf-8'))
+
+    duplicates: list[tuple[float, str]] = []
+    for heading, body in repo_sections.items():
+        if not body:
+            continue
+        for ws_body in workspace_sections.values():
+            ratio = similarity(body, ws_body)
+            if ratio >= threshold:
+                duplicates.append((ratio, heading))
+                break  # one match is enough per heading
+
+    return sorted(duplicates, key=lambda x: x[0], reverse=True)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Detect duplicated copilot-instructions sections and return 1 if any found."""
+    parser = argparse.ArgumentParser(
+        description='Detect sections in per-repo copilot-instructions.md already in workspace instructions',
+    )
+    parser.add_argument('filenames', nargs='*', help='staged files passed by pre-commit')
+    parser.add_argument(
+        '--threshold',
+        type=float,
+        default=_DEFAULT_THRESHOLD,
+        help='similarity threshold 0-1 above which a section is flagged (default: 0.80)',
+    )
+    args = parser.parse_args(argv)
+
+    ret_val = 0
+    for filename in args.filenames:
+        repo_file = Path(filename).resolve()
+        if not repo_file.exists():
+            continue
+
+        workspace_file = find_workspace_instructions(repo_file)
+        if workspace_file is None:
+            # No workspace instructions found — pass silently
+            continue
+
+        duplicates = check_duplications(repo_file, workspace_file, args.threshold)
+        if duplicates:
+            print(  # print-detection: disable
+                f'[detect-duplicated-copilot-instructions] Found {len(duplicates)} section(s)'
+                f' already in workspace instructions ({workspace_file}):',
+            )
+            for ratio, heading in duplicates:
+                print(f'  [{ratio:.0%}] ## {heading}')  # print-detection: disable
+            print(  # print-detection: disable
+                'Remove them from the per-repo file — keep only repo-specific content.',
+            )
+            ret_val = 1
+
+    return ret_val
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ js-syntax-check = "pre_commit_hooks.js_syntax_check:main"
 ts-hardcoded-secret-detection = "pre_commit_hooks.ts_hardcoded_secret:main"  # pragma: allowlist secret
 generate-changelog = "pre_commit_hooks.generate_changelog:main"
 regression-gate = "pre_commit_hooks.regression_gate:main"
+detect-duplicated-copilot-instructions = "pre_commit_hooks.copilot_instructions_duplication:main"
 
 [project.optional-dependencies]
 dead_code = ["vulture>=2.0"]

--- a/tests/test_copilot_instructions_duplication.py
+++ b/tests/test_copilot_instructions_duplication.py
@@ -1,0 +1,190 @@
+"""Tests for copilot_instructions_duplication hook."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pre_commit_hooks.copilot_instructions_duplication import (
+    check_duplications,
+    extract_sections,
+    find_workspace_instructions,
+    main,
+    similarity,
+)
+
+_INSTRUCTIONS_PATH = Path('.github') / 'copilot-instructions.md'
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding='utf-8')
+
+
+class TestExtractSections:
+    def test_single_section(self) -> None:
+        text = '## My Section\n\nSome content here.\n'
+        sections = extract_sections(text)
+        assert 'My Section' in sections
+        assert 'Some content here.' in sections['My Section']
+
+    def test_multiple_sections(self) -> None:
+        text = '## Section A\n\nContent A.\n\n## Section B\n\nContent B.\n'
+        sections = extract_sections(text)
+        assert 'Section A' in sections
+        assert 'Section B' in sections
+
+    def test_no_sections(self) -> None:
+        text = '# H1 heading\n\nSome text.\n'
+        assert extract_sections(text) == {}
+
+    def test_empty_body_section(self) -> None:
+        text = '## Empty Section\n\n## Non-empty\n\nContent.\n'
+        sections = extract_sections(text)
+        assert sections['Empty Section'] == ''
+        assert 'Content.' in sections['Non-empty']
+
+
+class TestSimilarity:
+    def test_identical_strings(self) -> None:
+        assert similarity('hello', 'hello') == 1.0
+
+    def test_completely_different(self) -> None:
+        assert similarity('abc', 'xyz') < 0.5
+
+    def test_partial_overlap(self) -> None:
+        ratio = similarity('hello world', 'hello there')
+        assert 0.0 < ratio < 1.0
+
+
+class TestFindWorkspaceInstructions:
+    def test_finds_workspace_file_above_repo(self, tmp_path: Path) -> None:
+        # Structure: tmp_path/.github/copilot-instructions.md (workspace)
+        #            tmp_path/chrysa/my-repo/.github/copilot-instructions.md (repo)
+        ws_file = tmp_path / '.github' / 'copilot-instructions.md'
+        _write(ws_file, '## Workspace Section\n\nContent.\n')
+
+        repo_file = tmp_path / 'chrysa' / 'my-repo' / '.github' / 'copilot-instructions.md'
+        _write(repo_file, '## Repo Section\n\nContent.\n')
+
+        found = find_workspace_instructions(repo_file)
+        assert found is not None
+        assert found.resolve() == ws_file.resolve()
+
+    def test_returns_none_when_no_workspace_file(self, tmp_path: Path) -> None:
+        repo_file = tmp_path / 'chrysa' / 'my-repo' / '.github' / 'copilot-instructions.md'
+        _write(repo_file, '## Section\n\nContent.\n')
+
+        found = find_workspace_instructions(repo_file)
+        assert found is None
+
+    def test_does_not_return_same_file(self, tmp_path: Path) -> None:
+        # Only one instructions file exists — should not return itself
+        repo_file = tmp_path / '.github' / 'copilot-instructions.md'
+        _write(repo_file, '## Section\n\nContent.\n')
+
+        found = find_workspace_instructions(repo_file)
+        assert found is None
+
+
+class TestCheckDuplications:
+    def test_identical_section_flagged(self, tmp_path: Path) -> None:
+        body = 'You must automate everything including CI/CD pipelines and linting.\n' * 5
+        ws_file = tmp_path / 'ws' / _INSTRUCTIONS_PATH
+        _write(ws_file, f'## Automation Rules\n\n{body}')
+
+        repo_file = tmp_path / 'repo' / _INSTRUCTIONS_PATH
+        _write(repo_file, f'## Automation Rules\n\n{body}')
+
+        duplicates = check_duplications(repo_file, ws_file, threshold=0.80)
+        assert len(duplicates) == 1
+        assert duplicates[0][1] == 'Automation Rules'
+        assert duplicates[0][0] >= 0.80
+
+    def test_different_section_not_flagged(self, tmp_path: Path) -> None:
+        ws_file = tmp_path / 'ws' / _INSTRUCTIONS_PATH
+        _write(ws_file, '## Global Rule\n\nAlways use Docker for builds.\n')
+
+        repo_file = tmp_path / 'repo' / _INSTRUCTIONS_PATH
+        _write(repo_file, '## Repo-Specific Rule\n\nThis project uses PostgreSQL 17.\n')
+
+        duplicates = check_duplications(repo_file, ws_file, threshold=0.80)
+        assert duplicates == []
+
+    def test_below_threshold_not_flagged(self, tmp_path: Path) -> None:
+        ws_file = tmp_path / 'ws' / _INSTRUCTIONS_PATH
+        _write(ws_file, '## CI\n\nRun tests in Docker always.\n')
+
+        repo_file = tmp_path / 'repo' / _INSTRUCTIONS_PATH
+        _write(repo_file, '## CI\n\nUse GitHub Actions for CI.\n')
+
+        duplicates = check_duplications(repo_file, ws_file, threshold=0.95)
+        assert duplicates == []
+
+    def test_disable_comment_skips_file(self, tmp_path: Path) -> None:
+        body = 'You must automate everything including CI/CD pipelines and linting.\n' * 5
+        ws_file = tmp_path / 'ws' / _INSTRUCTIONS_PATH
+        _write(ws_file, f'## Automation Rules\n\n{body}')
+
+        repo_file = tmp_path / 'repo' / _INSTRUCTIONS_PATH
+        _write(
+            repo_file,
+            f'<!-- detect-duplicated-copilot-instructions: disable -->\n## Automation Rules\n\n{body}',
+        )
+
+        duplicates = check_duplications(repo_file, ws_file, threshold=0.80)
+        assert duplicates == []
+
+    def test_empty_body_not_flagged(self, tmp_path: Path) -> None:
+        ws_file = tmp_path / 'ws' / _INSTRUCTIONS_PATH
+        _write(ws_file, '## Rule\n\nSome content.\n')
+
+        repo_file = tmp_path / 'repo' / _INSTRUCTIONS_PATH
+        _write(repo_file, '## Rule\n\n')
+
+        duplicates = check_duplications(repo_file, ws_file, threshold=0.80)
+        assert duplicates == []
+
+
+class TestMain:
+    def test_no_workspace_file_returns_0(self, tmp_path: Path) -> None:
+        repo_file = tmp_path / 'chrysa' / 'repo' / _INSTRUCTIONS_PATH
+        _write(repo_file, '## Section\n\nSome unique content here.\n')
+        assert main([str(repo_file)]) == 0
+
+    def test_duplicate_section_returns_1(self, tmp_path: Path) -> None:
+        body = 'Automate everything: CI, linting, formatting, testing, releases.\n' * 5
+        ws_file = tmp_path / _INSTRUCTIONS_PATH
+        _write(ws_file, f'## Automation\n\n{body}')
+
+        repo_file = tmp_path / 'chrysa' / 'repo' / _INSTRUCTIONS_PATH
+        _write(repo_file, f'## Automation\n\n{body}')
+
+        assert main([str(repo_file)]) == 1
+
+    def test_unique_section_returns_0(self, tmp_path: Path) -> None:
+        ws_file = tmp_path / _INSTRUCTIONS_PATH
+        _write(ws_file, '## Global\n\nGlobal engineering rules here.\n')
+
+        repo_file = tmp_path / 'chrysa' / 'repo' / _INSTRUCTIONS_PATH
+        _write(repo_file, '## Project-Specific\n\nThis repo uses a Rust backend.\n')
+
+        assert main([str(repo_file)]) == 0
+
+    def test_custom_threshold_respected(self, tmp_path: Path) -> None:
+        # Sections are ~85% similar — should fail at 0.80 but pass at 0.95
+        body_ws = 'All tests must run in Docker containers via make targets.\n' * 5
+        body_repo = 'All tests must run in Docker containers via Makefile targets.\n' * 5
+
+        ws_file = tmp_path / _INSTRUCTIONS_PATH
+        _write(ws_file, f'## Tests\n\n{body_ws}')
+
+        repo_file = tmp_path / 'chrysa' / 'repo' / _INSTRUCTIONS_PATH
+        _write(repo_file, f'## Tests\n\n{body_repo}')
+
+        assert main([str(repo_file), '--threshold', '0.95']) == 0
+
+    def test_empty_filenames_returns_0(self) -> None:
+        assert main([]) == 0
+
+    def test_nonexistent_file_skipped(self, tmp_path: Path) -> None:
+        assert main([str(tmp_path / 'nonexistent.md')]) == 0


### PR DESCRIPTION
Part of the chrysa ecosystem CI standardization effort.

CI change: Replace inline `pip install -e` with `install-project@v1` composite action.

Also includes the main feature for issue #161 (detect duplicated copilot instructions).