### PR TITLE
chore(pre-commit): add missing chrysa hooks from standards audit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -211,5 +211,8 @@ repos:
   - repo: https://github.com/chrysa/pre-commit-tools
     rev: v0.1.1-76
     hooks:
+      - id: adr-gate
+      - id: no-bare-except
+      - id: no-sync-in-async
       - id: regression-gate
         stages: [pre-push]


### PR DESCRIPTION
Part of ecosystem-wide standards audit. Adds missing chrysa/pre-commit-tools hooks based on repo stack detection.

Related: chrysa/pre-commit-tools#168 chrysa/pre-commit-tools#169 chrysa/pre-commit-tools#170 chrysa/pre-commit-tools#171 chrysa/pre-commit-tools#172 chrysa/pre-commit-tools#173