### PR TITLE
feat(hooks): add 6 new detection hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -331,3 +331,52 @@
   minimum_pre_commit_version: '4.1.0'
   name: detect async useEffect (use useCallback + useEffect instead)
   types_or: ["tsx", "jsx", "file"]
+- id: dockerfile-multi-stage-check
+  description: detect Dockerfiles that do not use a multi-stage build (fewer than 2 FROM stages)
+  entry: dockerfile-multi-stage-check
+  files: '(^|/)Dockerfile[^/]*$'
+  language: python
+  minimum_pre_commit_version: '4.1.0'
+  name: detect missing multi-stage build in Dockerfiles
+  types_or: ["dockerfile", "file"]
+- id: dockerfile-healthcheck
+  description: detect Dockerfiles missing a HEALTHCHECK instruction in the final stage
+  entry: dockerfile-healthcheck
+  files: '(^|/)Dockerfile[^/]*$'
+  language: python
+  minimum_pre_commit_version: '4.1.0'
+  name: detect missing HEALTHCHECK in Dockerfiles
+  types_or: ["dockerfile", "file"]
+- id: dockerfile-non-root-user
+  description: detect Dockerfiles where the final stage runs as root (no USER or USER root)
+  entry: dockerfile-non-root-user
+  files: '(^|/)Dockerfile[^/]*$'
+  language: python
+  minimum_pre_commit_version: '4.1.0'
+  name: detect root user in Dockerfile final stage
+  types_or: ["dockerfile", "file"]
+- id: ts-no-any
+  description: 'detect explicit `any` type usage (`: any`, `as any`, `<any>`) in TypeScript files'
+  entry: ts-no-any
+  exclude: 'tests?/|\.test\.|\.spec\.'
+  files: \.(ts|tsx)$
+  language: python
+  minimum_pre_commit_version: '4.1.0'
+  name: detect `any` type in TypeScript
+  types_or: ["ts", "tsx", "file"]
+- id: react-no-inline-styles
+  description: detect `style={{...}}` inline styles in React/JSX/TSX files
+  entry: react-no-inline-styles
+  files: \.(tsx|jsx)$
+  language: python
+  minimum_pre_commit_version: '4.1.0'
+  name: detect inline styles in React components
+  types_or: ["tsx", "jsx", "file"]
+- id: python-no-type-ignore
+  description: 'detect `# type: ignore` without a justification comment in Python files'
+  entry: python-no-type-ignore
+  files: \.py$
+  language: python
+  minimum_pre_commit_version: '4.1.0'
+  name: 'detect bare # type: ignore without justification'
+  types: ["python"]

--- a/pre_commit_hooks/dockerfile_healthcheck.py
+++ b/pre_commit_hooks/dockerfile_healthcheck.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python3
+"""Hook to detect Dockerfiles missing a HEALTHCHECK instruction."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+_DISABLE_COMMENT = '# dockerfile-healthcheck: disable'
+_FROM_RE = re.compile(r'^\s*FROM\s+', re.IGNORECASE)
+_HEALTHCHECK_RE = re.compile(r'^\s*HEALTHCHECK\s+', re.IGNORECASE)
+
+Violation = tuple[str, int, str]
+
+
+def detect_missing_healthcheck(source: str, filename: str) -> list[Violation]:
+    """Return a violation when the Dockerfile's final stage has no HEALTHCHECK."""
+    if _DISABLE_COMMENT in source:
+        return []
+
+    lines = source.splitlines()
+    last_from_lineno: int | None = None
+    for idx, line in enumerate(lines):
+        if line.strip().startswith('#'):
+            continue
+        if _FROM_RE.match(line):
+            last_from_lineno = idx
+
+    if last_from_lineno is None:
+        return []
+
+    for line in lines[last_from_lineno:]:
+        if line.strip().startswith('#'):
+            continue
+        if _HEALTHCHECK_RE.match(line):
+            return []
+
+    return [
+        (
+            filename,
+            last_from_lineno + 1,
+            'Dockerfile final stage is missing a HEALTHCHECK instruction',
+        ),
+    ]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Detect Dockerfiles missing HEALTHCHECK and return 1 if any found."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Detect Dockerfiles missing HEALTHCHECK instruction',
+    )
+    parser.add_argument('filenames', nargs='*')
+    args = parser.parse_args(argv)
+
+    retval = 0
+    for filename in args.filenames:
+        try:
+            with open(filename, encoding='utf-8') as f:
+                source = f.read()
+        except OSError, UnicodeDecodeError:
+            continue
+        for fname, lineno, msg in detect_missing_healthcheck(source, filename):
+            print(f'{fname}:{lineno}: {msg}')
+            retval = 1
+    return retval
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/pre_commit_hooks/dockerfile_multi_stage_check.py
+++ b/pre_commit_hooks/dockerfile_multi_stage_check.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+"""Hook to detect Dockerfiles that are missing a multi-stage build pattern."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+_DISABLE_COMMENT = '# dockerfile-multi-stage-check: disable'
+_FROM_RE = re.compile(r'^\s*FROM\s+\S+', re.IGNORECASE)
+_FROM_SCRATCH_RE = re.compile(r'^\s*FROM\s+scratch(\s|$)', re.IGNORECASE)
+
+Violation = tuple[str, int, str]
+
+
+def detect_missing_multi_stage(source: str, filename: str) -> list[Violation]:
+    """Return violations when the Dockerfile has only one non-scratch FROM stage."""
+    if _DISABLE_COMMENT in source:
+        return []
+
+    from_count = 0
+    for line in source.splitlines():
+        line_stripped = line.strip()
+        if line_stripped.startswith('#'):
+            continue
+        if _FROM_RE.match(line) and not _FROM_SCRATCH_RE.match(line):
+            from_count += 1
+
+    if from_count < 2:
+        return [
+            (
+                filename,
+                1,
+                f'Dockerfile has only {from_count} FROM stage(s); multi-stage builds required '
+                '(deps → builder → production)',
+            ),
+        ]
+    return []
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Detect Dockerfiles missing multi-stage builds and return 1 if any found."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Detect Dockerfiles missing multi-stage build pattern',
+    )
+    parser.add_argument('filenames', nargs='*')
+    args = parser.parse_args(argv)
+
+    retval = 0
+    for filename in args.filenames:
+        try:
+            with open(filename, encoding='utf-8') as f:
+                source = f.read()
+        except OSError, UnicodeDecodeError:
+            continue
+        for fname, lineno, msg in detect_missing_multi_stage(source, filename):
+            print(f'{fname}:{lineno}: {msg}')
+            retval = 1
+    return retval
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/pre_commit_hooks/dockerfile_non_root_user.py
+++ b/pre_commit_hooks/dockerfile_non_root_user.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python3
+"""Hook to detect Dockerfiles where the final stage runs as root."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+_DISABLE_COMMENT = '# dockerfile-non-root-user: disable'
+_FROM_RE = re.compile(r'^\s*FROM\s+', re.IGNORECASE)
+_USER_RE = re.compile(r'^\s*USER\s+(\S+)', re.IGNORECASE)
+_ROOT_USER_RE = re.compile(r'^\s*USER\s+root\b', re.IGNORECASE)
+
+Violation = tuple[str, int, str]
+
+
+def detect_root_user(source: str, filename: str) -> list[Violation]:
+    """Return a violation when the Dockerfile's final stage has no USER or uses USER root."""
+    if _DISABLE_COMMENT in source:
+        return []
+
+    lines = source.splitlines()
+    last_from_lineno: int | None = None
+    for idx, line in enumerate(lines):
+        if line.strip().startswith('#'):
+            continue
+        if _FROM_RE.match(line):
+            last_from_lineno = idx
+
+    if last_from_lineno is None:
+        return []
+
+    final_stage_lines = lines[last_from_lineno:]
+    user_found = False
+
+    for idx, line in enumerate(final_stage_lines):
+        if line.strip().startswith('#'):
+            continue
+        if _ROOT_USER_RE.match(line):
+            return [
+                (
+                    filename,
+                    last_from_lineno + idx + 1,
+                    'Dockerfile final stage uses USER root; switch to a non-root user',
+                ),
+            ]
+        if _USER_RE.match(line):
+            user_found = True
+
+    if not user_found:
+        return [
+            (
+                filename,
+                last_from_lineno + 1,
+                'Dockerfile final stage has no USER instruction; add a non-root user',
+            ),
+        ]
+    return []
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Detect Dockerfiles with missing or root USER in final stage; return 1 if found."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Detect Dockerfiles running as root in the final stage',
+    )
+    parser.add_argument('filenames', nargs='*')
+    args = parser.parse_args(argv)
+
+    retval = 0
+    for filename in args.filenames:
+        try:
+            with open(filename, encoding='utf-8') as f:
+                source = f.read()
+        except OSError, UnicodeDecodeError:
+            continue
+        for fname, lineno, msg in detect_root_user(source, filename):
+            print(f'{fname}:{lineno}: {msg}')
+            retval = 1
+    return retval
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/pre_commit_hooks/python_no_type_ignore.py
+++ b/pre_commit_hooks/python_no_type_ignore.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+"""Hook to detect `# type: ignore` without an explanatory comment."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from pathlib import Path
+
+# Matches `# type: ignore` (with optional [qualifier]) not followed by another `#` comment
+_TYPE_IGNORE_NO_REASON_RE = re.compile(
+    r'#\s*type:\s*ignore(?:\[.*?\])?\s*$',
+)
+_DISABLE_COMMENT = '# python-no-type-ignore: disable'
+
+Violation = tuple[str, int, str]
+
+
+def detect_bare_type_ignore(source: str, filename: str) -> list[Violation]:
+    """Return violations for `# type: ignore` without a following justification comment."""
+    violations: list[Violation] = []
+    for lineno, line in enumerate(source.splitlines(), start=1):
+        if _DISABLE_COMMENT in line:
+            continue
+        if _TYPE_IGNORE_NO_REASON_RE.search(line):
+            violations.append(
+                (
+                    filename,
+                    lineno,
+                    '# type: ignore without justification comment (add e.g. `# type: ignore[attr-defined]  # reason`)',
+                ),
+            )
+    return violations
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Detect bare `# type: ignore` and return 1 if any found."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Detect # type: ignore without justification comment',
+    )
+    parser.add_argument('filenames', nargs='*')
+    args = parser.parse_args(argv)
+
+    retval = 0
+    for filename in args.filenames:
+        try:
+            source = Path(filename).read_text(encoding='utf-8')
+        except OSError, UnicodeDecodeError:
+            continue
+        for fname, lineno, msg in detect_bare_type_ignore(source, filename):
+            print(f'{fname}:{lineno}: {msg}')
+            retval = 1
+    return retval
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/pre_commit_hooks/react_no_inline_styles.py
+++ b/pre_commit_hooks/react_no_inline_styles.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Hook to detect inline styles in React/JSX files."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+from pre_commit_hooks.tools.pattern_detection import PatternDetection
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Detect `style={{...}}` inline styles in React/JSX/TSX files."""
+    pattern_detection = PatternDetection(
+        commented=re.compile(r'^\s*//'),
+        disable_comment=re.compile(r'react-no-inline-styles\s*:\s*disable'),
+        pattern=re.compile(r'style\s*=\s*\{\{'),
+    )
+    return pattern_detection.detect(argv=argv)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/pre_commit_hooks/ts_no_any.py
+++ b/pre_commit_hooks/ts_no_any.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Hook to detect `any` type usage in TypeScript files."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+from pre_commit_hooks.tools.pattern_detection import PatternDetection
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Detect explicit `any` type annotations in TypeScript files."""
+    pattern_detection = PatternDetection(
+        commented=re.compile(r'^\s*//'),
+        disable_comment=re.compile(r'ts-no-any\s*:\s*disable'),
+        pattern=re.compile(r':\s*any\b|as\s+any\b|<\s*any\s*>'),
+    )
+    return pattern_detection.detect(argv=argv)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,12 @@ helm-lint = "pre_commit_hooks.helm_lint:main"
 no-hardcoded-localhost = "pre_commit_hooks.no_hardcoded_localhost:main"
 fastapi-missing-links = "pre_commit_hooks.fastapi_missing_links:main"
 react-no-async-in-useeffect = "pre_commit_hooks.react_no_async_in_useeffect:main"
+dockerfile-multi-stage-check = "pre_commit_hooks.dockerfile_multi_stage_check:main"
+dockerfile-healthcheck = "pre_commit_hooks.dockerfile_healthcheck:main"
+dockerfile-non-root-user = "pre_commit_hooks.dockerfile_non_root_user:main"
+ts-no-any = "pre_commit_hooks.ts_no_any:main"
+react-no-inline-styles = "pre_commit_hooks.react_no_inline_styles:main"
+python-no-type-ignore = "pre_commit_hooks.python_no_type_ignore:main"
 
 [project.optional-dependencies]
 dead_code = ["vulture>=2.0"]

--- a/tests/test_dockerfile_healthcheck.py
+++ b/tests/test_dockerfile_healthcheck.py
@@ -1,0 +1,71 @@
+"""Tests for dockerfile_healthcheck."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pre_commit_hooks.dockerfile_healthcheck import detect_missing_healthcheck, main
+
+
+def _write(tmp_path: Path, name: str, content: str) -> str:
+    p = tmp_path / name
+    p.write_text(content, encoding='utf-8')
+    return str(p)
+
+
+class TestDetectMissingHealthcheck:
+    def test_healthcheck_present_ok(self) -> None:
+        src = (
+            'FROM python:3.12 AS builder\n'
+            'RUN pip install app\n'
+            'FROM python:3.12-slim\n'
+            'COPY --from=builder /app /app\n'
+            'HEALTHCHECK CMD curl -f http://localhost:8000/health || exit 1\n'
+        )
+        assert detect_missing_healthcheck(src, 'Dockerfile') == []
+
+    def test_missing_healthcheck_detected(self) -> None:
+        src = 'FROM python:3.12-slim\nRUN pip install app\n'
+        violations = detect_missing_healthcheck(src, 'Dockerfile')
+        assert len(violations) == 1
+        _fname, _lineno, msg = violations[0]
+        assert 'HEALTHCHECK' in msg
+
+    def test_healthcheck_in_builder_stage_not_final(self) -> None:
+        src = (
+            'FROM python:3.12 AS builder\n'
+            'HEALTHCHECK CMD curl -f http://localhost/health || exit 1\n'
+            'FROM python:3.12-slim\n'
+            'COPY --from=builder /app /app\n'
+        )
+        violations = detect_missing_healthcheck(src, 'Dockerfile')
+        assert len(violations) == 1
+
+    def test_disable_comment_suppresses(self) -> None:
+        src = '# dockerfile-healthcheck: disable\nFROM python:3.12-slim\n'
+        assert detect_missing_healthcheck(src, 'Dockerfile') == []
+
+    def test_empty_dockerfile_no_violation(self) -> None:
+        src = '# just a comment\n'
+        assert detect_missing_healthcheck(src, 'Dockerfile') == []
+
+    def test_healthcheck_case_insensitive(self) -> None:
+        src = 'FROM python:3.12-slim\nhealthcheck CMD curl -f http://localhost/health || exit 1\n'
+        assert detect_missing_healthcheck(src, 'Dockerfile') == []
+
+
+class TestDockerfileHealthcheckMain:
+    def test_with_healthcheck_returns_0(self, tmp_path: Path) -> None:
+        f = _write(
+            tmp_path,
+            'Dockerfile',
+            'FROM python:3.12-slim\nHEALTHCHECK CMD curl -f http://localhost/health || exit 1\n',
+        )
+        assert main([f]) == 0
+
+    def test_missing_healthcheck_returns_1(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'Dockerfile', 'FROM python:3.12-slim\nRUN echo ok\n')
+        assert main([f]) == 1
+
+    def test_empty_args_returns_0(self) -> None:
+        assert main([]) == 0

--- a/tests/test_dockerfile_multi_stage_check.py
+++ b/tests/test_dockerfile_multi_stage_check.py
@@ -1,0 +1,70 @@
+"""Tests for dockerfile_multi_stage_check."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pre_commit_hooks.dockerfile_multi_stage_check import detect_missing_multi_stage, main
+
+
+def _write(tmp_path: Path, name: str, content: str) -> str:
+    p = tmp_path / name
+    p.write_text(content, encoding='utf-8')
+    return str(p)
+
+
+class TestDetectMissingMultiStage:
+    def test_single_stage_detected(self) -> None:
+        src = 'FROM python:3.12-slim\nRUN pip install app\n'
+        violations = detect_missing_multi_stage(src, 'Dockerfile')
+        assert len(violations) == 1
+        _fname, _lineno, msg = violations[0]
+        assert 'multi-stage' in msg.lower()
+
+    def test_multi_stage_ok(self) -> None:
+        src = 'FROM python:3.12 AS builder\nRUN pip install app\nFROM python:3.12-slim\nCOPY --from=builder /app /app\n'
+        assert detect_missing_multi_stage(src, 'Dockerfile') == []
+
+    def test_three_stages_ok(self) -> None:
+        src = 'FROM node:18 AS deps\nFROM node:18 AS builder\nFROM nginx:1.25\n'
+        assert detect_missing_multi_stage(src, 'Dockerfile') == []
+
+    def test_from_scratch_only_detected(self) -> None:
+        src = 'FROM scratch\nCOPY app /app\n'
+        violations = detect_missing_multi_stage(src, 'Dockerfile')
+        assert len(violations) == 1
+
+    def test_from_scratch_plus_real_ok(self) -> None:
+        src = 'FROM golang:1.21 AS builder\nRUN go build\nFROM scratch\nCOPY --from=builder /app /app\n'
+        assert detect_missing_multi_stage(src, 'Dockerfile') == []
+
+    def test_empty_dockerfile_no_violation(self) -> None:
+        src = '# just a comment\n'
+        violations = detect_missing_multi_stage(src, 'Dockerfile')
+        assert len(violations) == 1
+
+    def test_disable_comment_suppresses(self) -> None:
+        src = '# dockerfile-multi-stage-check: disable\nFROM python:3.12\n'
+        assert detect_missing_multi_stage(src, 'Dockerfile') == []
+
+    def test_comment_line_ignored(self) -> None:
+        src = '# FROM python:3.12\nFROM python:3.12-slim\n'
+        violations = detect_missing_multi_stage(src, 'Dockerfile')
+        assert len(violations) == 1
+
+
+class TestDockerfileMultiStageCheckMain:
+    def test_multi_stage_returns_0(self, tmp_path: Path) -> None:
+        f = _write(
+            tmp_path,
+            'Dockerfile',
+            'FROM python:3.12 AS builder\nFROM python:3.12-slim\n',
+        )
+        assert main([f]) == 0
+
+    def test_single_stage_returns_1(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'Dockerfile', 'FROM python:3.12-slim\nRUN echo ok\n')
+        assert main([f]) == 1
+
+    def test_empty_args_returns_0(self) -> None:
+        assert main([]) == 0

--- a/tests/test_dockerfile_non_root_user.py
+++ b/tests/test_dockerfile_non_root_user.py
@@ -1,0 +1,75 @@
+"""Tests for dockerfile_non_root_user."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pre_commit_hooks.dockerfile_non_root_user import detect_root_user, main
+
+
+def _write(tmp_path: Path, name: str, content: str) -> str:
+    p = tmp_path / name
+    p.write_text(content, encoding='utf-8')
+    return str(p)
+
+
+class TestDetectRootUser:
+    def test_non_root_user_ok(self) -> None:
+        src = 'FROM python:3.12-slim\nUSER appuser\n'
+        assert detect_root_user(src, 'Dockerfile') == []
+
+    def test_numeric_user_ok(self) -> None:
+        src = 'FROM python:3.12-slim\nUSER 1001\n'
+        assert detect_root_user(src, 'Dockerfile') == []
+
+    def test_missing_user_detected(self) -> None:
+        src = 'FROM python:3.12-slim\nRUN pip install app\n'
+        violations = detect_root_user(src, 'Dockerfile')
+        assert len(violations) == 1
+        _fname, _lineno, msg = violations[0]
+        assert 'USER' in msg
+
+    def test_user_root_detected(self) -> None:
+        src = 'FROM python:3.12-slim\nUSER root\n'
+        violations = detect_root_user(src, 'Dockerfile')
+        assert len(violations) == 1
+        _fname, _lineno, msg = violations[0]
+        assert 'root' in msg
+
+    def test_multi_stage_checks_final_stage_only(self) -> None:
+        src = 'FROM python:3.12 AS builder\nUSER root\nFROM python:3.12-slim\nUSER appuser\n'
+        assert detect_root_user(src, 'Dockerfile') == []
+
+    def test_multi_stage_final_stage_no_user(self) -> None:
+        src = 'FROM python:3.12 AS builder\nUSER appuser\nFROM python:3.12-slim\nRUN echo ok\n'
+        violations = detect_root_user(src, 'Dockerfile')
+        assert len(violations) == 1
+
+    def test_disable_comment_suppresses(self) -> None:
+        src = '# dockerfile-non-root-user: disable\nFROM python:3.12-slim\n'
+        assert detect_root_user(src, 'Dockerfile') == []
+
+    def test_empty_dockerfile_no_violation(self) -> None:
+        src = '# just a comment\n'
+        assert detect_root_user(src, 'Dockerfile') == []
+
+    def test_user_case_insensitive(self) -> None:
+        src = 'FROM python:3.12-slim\nuser appuser\n'
+        assert detect_root_user(src, 'Dockerfile') == []
+
+
+class TestDockerfileNonRootUserMain:
+    def test_non_root_returns_0(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'Dockerfile', 'FROM python:3.12-slim\nUSER appuser\n')
+        assert main([f]) == 0
+
+    def test_no_user_returns_1(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'Dockerfile', 'FROM python:3.12-slim\nRUN echo ok\n')
+        assert main([f]) == 1
+
+    def test_user_root_returns_1(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'Dockerfile', 'FROM python:3.12-slim\nUSER root\n')
+        assert main([f]) == 1
+
+    def test_empty_args_returns_0(self) -> None:
+        assert main([]) == 0

--- a/tests/test_python_no_type_ignore.py
+++ b/tests/test_python_no_type_ignore.py
@@ -1,0 +1,77 @@
+"""Tests for python_no_type_ignore."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pre_commit_hooks.python_no_type_ignore import detect_bare_type_ignore, main
+
+
+def _write(tmp_path: Path, name: str, content: str) -> str:
+    p = tmp_path / name
+    p.write_text(content, encoding='utf-8')
+    return str(p)
+
+
+class TestDetectBareTypeIgnore:
+    def test_bare_type_ignore_detected(self) -> None:
+        src = 'x = some_fn()  # type: ignore\n'
+        violations = detect_bare_type_ignore(src, 'file.py')
+        assert len(violations) == 1
+        _fname, _lineno, msg = violations[0]
+        assert 'justification' in msg
+
+    def test_type_ignore_with_qualifier_only_detected(self) -> None:
+        src = 'x = some_fn()  # type: ignore[attr-defined]\n'
+        violations = detect_bare_type_ignore(src, 'file.py')
+        assert len(violations) == 1
+
+    def test_type_ignore_with_reason_ok(self) -> None:
+        src = 'x = some_fn()  # type: ignore[attr-defined]  # third-party lib missing stubs\n'
+        assert detect_bare_type_ignore(src, 'file.py') == []
+
+    def test_type_ignore_with_inline_reason_ok(self) -> None:
+        src = 'x = some_fn()  # type: ignore  # legacy code, cannot fix now\n'
+        assert detect_bare_type_ignore(src, 'file.py') == []
+
+    def test_disable_comment_suppresses(self) -> None:
+        src = 'x = some_fn()  # type: ignore  # python-no-type-ignore: disable\n'
+        assert detect_bare_type_ignore(src, 'file.py') == []
+
+    def test_multiple_violations_found(self) -> None:
+        src = 'a = foo()  # type: ignore\nb = bar()  # type: ignore[misc]\n'
+        violations = detect_bare_type_ignore(src, 'file.py')
+        assert len(violations) == 2
+
+    def test_no_type_ignore_ok(self) -> None:
+        src = 'x: int = 1\ny: str = "hello"\n'
+        assert detect_bare_type_ignore(src, 'file.py') == []
+
+    @pytest.mark.parametrize(
+        'line',
+        [
+            'x = f()  # type: ignore[return-value]  # reason here\n',
+            'x = f()  # type: ignore  # noqa: F401 — intentional\n',
+        ],
+    )
+    def test_with_reason_variants_ok(self, line: str) -> None:
+        assert detect_bare_type_ignore(line, 'file.py') == []
+
+
+class TestPythonNoTypeIgnoreMain:
+    def test_bare_ignore_returns_1(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'bad.py', 'x = f()  # type: ignore\n')
+        assert main([f]) == 1
+
+    def test_with_reason_returns_0(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'ok.py', 'x = f()  # type: ignore[misc]  # needed\n')
+        assert main([f]) == 0
+
+    def test_clean_file_returns_0(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'ok.py', 'x: int = 1\n')
+        assert main([f]) == 0
+
+    def test_empty_args_returns_0(self) -> None:
+        assert main([]) == 0

--- a/tests/test_react_no_inline_styles.py
+++ b/tests/test_react_no_inline_styles.py
@@ -1,0 +1,55 @@
+"""Tests for react_no_inline_styles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pre_commit_hooks.react_no_inline_styles import main
+
+
+def _write(tmp_path: Path, name: str, content: str) -> str:
+    p = tmp_path / name
+    p.write_text(content, encoding='utf-8')
+    return str(p)
+
+
+@pytest.mark.parametrize(
+    'stmt',
+    [
+        '<div style={{ color: "red" }}>\n',
+        'return <span style={{fontSize: 12}}/>;\n',
+        '<Component style={{ margin: 0, padding: 0 }} />\n',
+    ],
+)
+class TestReactNoInlineStylesDetection:
+    def test_inline_style_returns_1(self, tmp_path: Path, stmt: str) -> None:
+        f = _write(tmp_path, 'bad.tsx', stmt)
+        assert main([f]) == 1
+
+    def test_disable_comment_suppresses(self, tmp_path: Path, stmt: str) -> None:
+        line = stmt.rstrip('\n') + '  // react-no-inline-styles: disable\n'
+        f = _write(tmp_path, 'ok.tsx', line)
+        assert main([f]) == 0
+
+    def test_commented_line_suppressed(self, tmp_path: Path, stmt: str) -> None:
+        f = _write(tmp_path, 'ok.tsx', '// ' + stmt)
+        assert main([f]) == 0
+
+
+class TestReactNoInlineStylesClean:
+    def test_classname_ok(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'ok.tsx', '<div className="container">\n')
+        assert main([f]) == 0
+
+    def test_style_variable_ok(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'ok.tsx', '<div style={containerStyles}>\n')
+        assert main([f]) == 0
+
+    def test_empty_file_returns_0(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'ok.tsx', '')
+        assert main([f]) == 0
+
+    def test_empty_args_returns_0(self) -> None:
+        assert main([]) == 0

--- a/tests/test_ts_no_any.py
+++ b/tests/test_ts_no_any.py
@@ -1,0 +1,56 @@
+"""Tests for ts_no_any."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pre_commit_hooks.ts_no_any import main
+
+
+def _write(tmp_path: Path, name: str, content: str) -> str:
+    p = tmp_path / name
+    p.write_text(content, encoding='utf-8')
+    return str(p)
+
+
+@pytest.mark.parametrize(
+    'stmt',
+    [
+        'const x: any = value;\n',
+        'function foo(x: any): void {}\n',
+        'const y = value as any;\n',
+        'const z = (<any>value);\n',
+    ],
+)
+class TestTsNoAnyDetection:
+    def test_any_usage_returns_1(self, tmp_path: Path, stmt: str) -> None:
+        f = _write(tmp_path, 'bad.ts', stmt)
+        assert main([f]) == 1
+
+    def test_disable_comment_suppresses(self, tmp_path: Path, stmt: str) -> None:
+        line = stmt.rstrip('\n') + '  // ts-no-any: disable\n'
+        f = _write(tmp_path, 'ok.ts', line)
+        assert main([f]) == 0
+
+    def test_commented_line_suppressed(self, tmp_path: Path, stmt: str) -> None:
+        f = _write(tmp_path, 'ok.ts', '// ' + stmt)
+        assert main([f]) == 0
+
+
+class TestTsNoAnyClean:
+    def test_typed_param_ok(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'ok.ts', 'function foo(x: string): void {}\n')
+        assert main([f]) == 0
+
+    def test_unknown_ok(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'ok.ts', 'const x: unknown = value;\n')
+        assert main([f]) == 0
+
+    def test_empty_file_returns_0(self, tmp_path: Path) -> None:
+        f = _write(tmp_path, 'ok.ts', '')
+        assert main([f]) == 0
+
+    def test_empty_args_returns_0(self) -> None:
+        assert main([]) == 0


### PR DESCRIPTION
## Summary

Add 6 new pre-commit detection hooks:

- **dockerfile-multi-stage-check** (#168): detect Dockerfiles with fewer than 2 FROM stages
- **dockerfile-healthcheck** (#169): detect Dockerfiles missing a HEALTHCHECK instruction in the final stage
- **dockerfile-non-root-user** (#170): detect Dockerfiles where the final stage runs as root
- **ts-no-any** (#171): detect explicit `any` type usage in TypeScript files
- **react-no-inline-styles** (#172): detect `style={{}}` inline styles in React/JSX/TSX files
- **python-no-type-ignore** (#173): detect bare `# type: ignore` without a justification comment

Each hook includes implementation, tests, pyproject.toml entry, and .pre-commit-hooks.yaml registration.

Closes #168, #169, #170, #171, #172, #173