### PR TITLE
fix(adr-gate): check git index directly to avoid false negative when hooks reorder staged files

### DIFF
--- a/pre_commit_hooks/adr_gate.py
+++ b/pre_commit_hooks/adr_gate.py
@@ -33,6 +33,22 @@ def get_added_files() -> list[str]:
     return [f for f in result.stdout.splitlines() if f]
 
 
+def get_all_staged_files() -> list[str]:
+    """Return all filenames currently staged in the index (any diff-filter).
+
+    Used to check for DECISIONS.md directly in the git index, bypassing
+    pre-commit's argv filtering which can exclude files when earlier hooks
+    (e.g. ruff-format) modify the working tree before adr-gate runs.
+    """
+    result = subprocess.run(
+        ['git', 'diff', '--cached', '--name-only'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return [f for f in result.stdout.splitlines() if f]
+
+
 def matches_any_pattern(filepath: str, patterns: list[str]) -> bool:
     """Return True if filepath matches any fnmatch pattern (full path or basename)."""
     name = Path(filepath).name
@@ -50,13 +66,14 @@ def check_adr_gate(
     trigger_patterns: list[str],
     decisions_file: str = 'DECISIONS.md',
     warn_only: bool = False,
+    all_staged_files: list[str] | None = None,
 ) -> int:
     """Run the ADR gate check.
 
     Parameters
     ----------
     staged_files:
-        All files currently staged (from pre-commit argv).
+        Files passed by pre-commit (filtered by the hook's types/files config).
     added_files:
         Files staged as newly added (git diff-filter A).
     trigger_patterns:
@@ -65,6 +82,10 @@ def check_adr_gate(
         Path to the decisions file to check (default: DECISIONS.md).
     warn_only:
         When True, print the warning but return 0 instead of 1.
+    all_staged_files:
+        All files staged in the git index (from git diff --cached --name-only).
+        When provided, used as a fallback to detect decisions_file even if
+        pre-commit's argv filtering excluded it (e.g. after ruff-format runs).
 
     Returns
     -------
@@ -75,7 +96,14 @@ def check_adr_gate(
     if not triggered:
         return 0
 
-    if decisions_file in staged_files:
+    # Check pre-commit argv first, then fall back to the full git index.
+    # This fixes a false negative where ruff-format (or any hook that modifies
+    # the working tree) runs before adr-gate and causes pre-commit to rebuild
+    # the staged-file list, potentially dropping DECISIONS.md from argv.
+    decisions_is_staged = decisions_file in staged_files or (
+        all_staged_files is not None and decisions_file in all_staged_files
+    )
+    if decisions_is_staged:
         return 0
 
     print('[adr-gate] Architecture-sensitive files detected:')  # print-detection: disable
@@ -115,6 +143,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     trigger_patterns = [p.strip() for p in args.trigger_patterns.split(',') if p.strip()]
     added = get_added_files()
+    all_staged = get_all_staged_files()
 
     return check_adr_gate(
         staged_files=args.filenames,
@@ -122,6 +151,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         trigger_patterns=trigger_patterns,
         decisions_file=args.decisions_file,
         warn_only=args.warn_only,
+        all_staged_files=all_staged,
     )
 
 

--- a/tests/test_adr_gate.py
+++ b/tests/test_adr_gate.py
@@ -6,7 +6,7 @@ import typing
 
 import pytest
 
-from pre_commit_hooks.adr_gate import check_adr_gate, matches_any_pattern
+from pre_commit_hooks.adr_gate import check_adr_gate, get_all_staged_files, matches_any_pattern
 
 
 class TestMatchesAnyPattern:
@@ -164,3 +164,51 @@ class TestCheckAdrGate:
             )
             == 0
         )
+
+    def test_decisions_in_all_staged_but_not_in_argv_returns_0(self) -> None:
+        """Regression test for #176: DECISIONS.md staged but absent from pre-commit argv.
+
+        This happens when ruff-format (or another hook) runs before adr-gate and
+        modifies the working tree, causing pre-commit to rebuild the staged-file list
+        without including DECISIONS.md in argv even though it is staged.
+        """
+        assert (
+            check_adr_gate(
+                staged_files=['api/routers/billing.py'],  # DECISIONS.md absent from argv
+                added_files=['api/routers/billing.py'],
+                trigger_patterns=self._PATTERNS,
+                all_staged_files=['api/routers/billing.py', 'DECISIONS.md'],  # present in git index
+            )
+            == 0
+        )
+
+    def test_decisions_absent_from_both_argv_and_git_index_returns_1(self) -> None:
+        """When DECISIONS.md is absent from both pre-commit argv and git index, return 1."""
+        assert (
+            check_adr_gate(
+                staged_files=['api/routers/billing.py'],
+                added_files=['api/routers/billing.py'],
+                trigger_patterns=self._PATTERNS,
+                all_staged_files=['api/routers/billing.py'],  # DECISIONS.md still absent
+            )
+            == 1
+        )
+
+    def test_all_staged_files_none_falls_back_to_staged_files_with_decisions(self) -> None:
+        """When all_staged_files is None, only staged_files (argv) is checked (backward compat)."""
+        assert (
+            check_adr_gate(
+                staged_files=['api/routers/billing.py', 'DECISIONS.md'],
+                added_files=['api/routers/billing.py'],
+                trigger_patterns=self._PATTERNS,
+                all_staged_files=None,
+            )
+            == 0
+        )
+
+
+class TestGetAllStagedFiles:
+    def test_returns_list(self, tmp_path: pytest.TempPathFactory) -> None:
+        """get_all_staged_files() always returns a list (even outside a git repo)."""
+        result = get_all_staged_files()
+        assert isinstance(result, list)


### PR DESCRIPTION
## Problem

Closes #176

When `ruff-format` (or any hook that modifies the working tree) runs **before** `adr-gate` in the pre-commit pipeline, pre-commit may rebuild its internal staged-file list and pass a different argv to subsequent hooks. As a result, `DECISIONS.md` can be excluded from `staged_files` (the pre-commit argv) even though it is properly staged in the git index — causing a false-negative failure: the hook incorrectly reports that `DECISIONS.md` was not updated.

## Root cause

`check_adr_gate()` only checked `decisions_file in staged_files` where `staged_files` is the argv passed by pre-commit. This list is filtered by the hook's `types`/`files` config and can differ from the actual git index state.

## Fix

1. Added `get_all_staged_files()` — queries `git diff --cached --name-only` to get the true git index contents (all diff statuses).
2. `check_adr_gate()` now accepts an optional `all_staged_files` parameter. The decisions-file check passes if `DECISIONS.md` is found in **either** source (pre-commit argv OR git index).
3. `main()` now calls `get_all_staged_files()` and passes the result as `all_staged_files`.

## Tests added

- `test_decisions_in_all_staged_but_not_in_argv_returns_0` — regression test for the exact bug
- `test_decisions_absent_from_both_argv_and_git_index_returns_1` — no false positive
- `test_all_staged_files_none_falls_back_to_staged_files_with_decisions` — backward compat
- `TestGetAllStagedFiles.test_returns_list` — smoke test for the new helper