### PR TITLE
chore(pre-commit): remove legacy setup-cfg-fmt, mirrors-pylint, mirrors-mypy hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,6 @@ default_language_version:
 fail_fast: false
 minimum_pre_commit_version: 4.1.0
 repos:
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v3.2.0
-    hooks:
-      - id: setup-cfg-fmt
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -74,25 +69,6 @@ repos:
         args: [--config=config-tools/ruff.toml, --fix]
       - id: ruff-format
         args: [--config=config-tools/ruff.toml]
-
-  - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v3.0.0a5
-    hooks:
-      - id: pylint
-        args:
-          - --rcfile=setup.cfg
-          - --reports=no
-          - --persistent=no
-          - --score=no
-          - --disable=E0401
-        stages: [manual]
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
-    hooks:
-      - id: mypy
-        args: [--config-file=setup.cfg]
-        stages: [manual]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0


### PR DESCRIPTION
## Summary

Remove 3 legacy hooks from the self-hosted `.pre-commit-config.yaml` that are superseded by existing tooling.

## Changes

### Removed
- `setup-cfg-fmt` — `pyproject.toml` is the standard, `setup.cfg` is obsolete
- `mirrors-pylint` (stage: manual) — replaced by `ruff-check` already present
- `mirrors-mypy` (stage: manual) — mypy runs in CI via `make typecheck`

## No behavior change
These hooks were all either stage=manual or replaced by ruff. The active commit-time linting is unaffected.