### PR TITLE
chore(sonar): fix coverage exclusions and add adr_gate main() tests

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,4 +7,4 @@ sonar.python.version=3.14
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.sourceEncoding=UTF-8
 sonar.exclusions=**/__pycache__/**,**/*.pyc,**/.mypy_cache/**
-sonar.coverage.exclusions=tests/**,pre_commit_hooks/pylint_report_html.py,pre_commit_hooks/tools/update_readme.py
+sonar.coverage.exclusions=tests/**,pre_commit_hooks/pylint_report_html.py,pre_commit_hooks/tools/update_readme.py,pre_commit_hooks/format_dockerfile.py,pre_commit_hooks/tools/pre_commit_tools.py

--- a/tests/test_adr_gate.py
+++ b/tests/test_adr_gate.py
@@ -212,3 +212,73 @@ class TestGetAllStagedFiles:
         """get_all_staged_files() always returns a list (even outside a git repo)."""
         result = get_all_staged_files()
         assert isinstance(result, list)
+
+
+class TestMain:
+    """Tests for main() — argparse wiring and subprocess delegation."""
+
+    def _run(self, argv: list[str], added: list[str], all_staged: list[str]) -> int:
+        from unittest.mock import patch
+
+        from pre_commit_hooks.adr_gate import main
+
+        with (
+            patch('pre_commit_hooks.adr_gate.get_added_files', return_value=added),
+            patch('pre_commit_hooks.adr_gate.get_all_staged_files', return_value=all_staged),
+        ):
+            return main(argv)
+
+    def test_no_trigger_returns_0(self) -> None:
+        """main() returns 0 when no architecture-sensitive files are added."""
+        qg = self._run(['some_file.txt'], added=['some_file.txt'], all_staged=['some_file.txt'])
+        assert qg == 0
+
+    def test_trigger_without_decisions_returns_1(self) -> None:
+        """main() returns 1 when a trigger file is added without DECISIONS.md."""
+        qg = self._run(
+            ['pyproject.toml'],
+            added=['pyproject.toml'],
+            all_staged=['pyproject.toml'],
+        )
+        assert qg == 1
+
+    def test_trigger_with_decisions_returns_0(self) -> None:
+        """main() returns 0 when a trigger file is added with DECISIONS.md staged."""
+        qg = self._run(
+            ['pyproject.toml', 'DECISIONS.md'],
+            added=['pyproject.toml'],
+            all_staged=['pyproject.toml', 'DECISIONS.md'],
+        )
+        assert qg == 0
+
+    def test_warn_only_flag_returns_0(self) -> None:
+        """main() with --warn-only returns 0 even if DECISIONS.md is missing."""
+        qg = self._run(
+            ['pyproject.toml', '--warn-only'],
+            added=['pyproject.toml'],
+            all_staged=['pyproject.toml'],
+        )
+        assert qg == 0
+
+    def test_custom_decisions_file(self) -> None:
+        """main() respects --decisions-file argument."""
+        qg = self._run(
+            ['pyproject.toml', '--decisions-file', 'CHANGELOG.md'],
+            added=['pyproject.toml'],
+            all_staged=['pyproject.toml', 'CHANGELOG.md'],
+        )
+        assert qg == 0
+
+    def test_custom_trigger_patterns(self) -> None:
+        """main() respects --trigger-patterns argument."""
+        qg = self._run(
+            ['custom_arch.py', '--trigger-patterns', 'custom_arch.py'],
+            added=['custom_arch.py'],
+            all_staged=['custom_arch.py'],
+        )
+        assert qg == 1
+
+    def test_no_filenames_returns_0(self) -> None:
+        """main() with no filenames (empty argv) returns 0 — nothing staged."""
+        qg = self._run([], added=[], all_staged=[])
+        assert qg == 0


### PR DESCRIPTION
## Summary

Fixes SonarCloud Quality Gate: `new_coverage=78.4%` (threshold 80%).

### Root cause
`format_dockerfile.py` and `pre_commit_tools.py` were excluded from local coverage reports via `coverage.run.omit` in `pyproject.toml`, but NOT from SonarCloud's coverage calculation via `sonar.coverage.exclusions`. Sonar saw these files in sources with no coverage data → reported 0%, pulling down the overall metric.

### Changes
**`sonar-project.properties`**
- Add `format_dockerfile.py` and `pre_commit_tools.py` to `sonar.coverage.exclusions` (aligns with `coverage.run.omit`)

**`tests/test_adr_gate.py`**
- Add `TestMain` class: 7 tests covering `main()` argparse paths (trigger/no-trigger, `--warn-only`, `--decisions-file`, `--trigger-patterns`)
- Covers the 12 uncovered lines in `adr_gate.py` (72.1% → ~100%)