### PR TITLE
fix(tooling): work around ruff py314 formatter bug + repair corrupted except clauses

### DIFF
--- a/config-tools/ruff.toml
+++ b/config-tools/ruff.toml
@@ -1,5 +1,6 @@
 line-length = 120
-target-version = "py314"
+# py313 (not py314): ruff format <=0.15.15 strips multi-except parens under py314 — restore when fixed upstream
+target-version = "py313"
 
 [lint]
 select = [

--- a/pre_commit_hooks/css_unused_variable.py
+++ b/pre_commit_hooks/css_unused_variable.py
@@ -63,7 +63,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for filename in args.filenames:
         try:
             source = Path(filename).read_text(encoding='utf-8')
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
         for fname, lineno, msg in detect_unused_variables(source, filename):
             print(f'{fname}:{lineno}: {msg}')  # print-detection: disable

--- a/pre_commit_hooks/django_hardcoded_secret.py
+++ b/pre_commit_hooks/django_hardcoded_secret.py
@@ -75,7 +75,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for filename in args.filenames:
         try:
             source = Path(filename).read_text(encoding='utf-8')
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
         for fname, lineno, msg in detect_hardcoded_secrets(source, filename):
             print(f'{fname}:{lineno}: {msg}')  # print-detection: disable

--- a/pre_commit_hooks/dockerfile_healthcheck.py
+++ b/pre_commit_hooks/dockerfile_healthcheck.py
@@ -59,7 +59,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             with open(filename, encoding='utf-8') as f:
                 source = f.read()
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
         for fname, lineno, msg in detect_missing_healthcheck(source, filename):
             print(f'{fname}:{lineno}: {msg}')

--- a/pre_commit_hooks/dockerfile_multi_stage_check.py
+++ b/pre_commit_hooks/dockerfile_multi_stage_check.py
@@ -53,7 +53,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             with open(filename, encoding='utf-8') as f:
                 source = f.read()
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
         for fname, lineno, msg in detect_missing_multi_stage(source, filename):
             print(f'{fname}:{lineno}: {msg}')

--- a/pre_commit_hooks/dockerfile_no_latest.py
+++ b/pre_commit_hooks/dockerfile_no_latest.py
@@ -42,7 +42,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             with open(filename, encoding='utf-8') as f:
                 source = f.read()
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
         for fname, lineno, msg in detect_from_latest(source, filename):
             print(f'{fname}:{lineno}: {msg}')

--- a/pre_commit_hooks/dockerfile_non_root_user.py
+++ b/pre_commit_hooks/dockerfile_non_root_user.py
@@ -73,7 +73,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             with open(filename, encoding='utf-8') as f:
                 source = f.read()
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
         for fname, lineno, msg in detect_root_user(source, filename):
             print(f'{fname}:{lineno}: {msg}')

--- a/pre_commit_hooks/env_example_sync.py
+++ b/pre_commit_hooks/env_example_sync.py
@@ -25,7 +25,7 @@ def _parse_keys(path: Path) -> set[str]:
                 m = _KEY_RE.match(line)
                 if m:
                     keys.add(m.group(1))
-    except OSError, UnicodeDecodeError:
+    except (OSError, UnicodeDecodeError):
         pass
     return keys
 

--- a/pre_commit_hooks/fastapi_missing_links.py
+++ b/pre_commit_hooks/fastapi_missing_links.py
@@ -112,7 +112,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for filename in args.filenames:
         try:
             source = Path(filename).read_text(encoding='utf-8')
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
         for fname, lineno, msg in detect_missing_links(source, filename):
             print(f'{fname}:{lineno}: {msg}', file=sys.stderr)

--- a/pre_commit_hooks/fastapi_missing_response_model.py
+++ b/pre_commit_hooks/fastapi_missing_response_model.py
@@ -100,7 +100,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for filename in args.filenames:
         try:
             source = Path(filename).read_text(encoding='utf-8')
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
         for fname, lineno, msg in detect_missing_response_model(source, filename):
             print(f'{fname}:{lineno}: {msg}', file=sys.stderr)

--- a/pre_commit_hooks/format_dockerfile.py
+++ b/pre_commit_hooks/format_dockerfile.py
@@ -37,7 +37,7 @@ def _load_config(config_path: Path) -> dict[str, bool]:
     try:
         data = tomllib.loads(config_path.read_text(encoding='utf-8'))
         return data.get('format-dockerfiles', {})
-    except OSError, tomllib.TOMLDecodeError:
+    except (OSError, tomllib.TOMLDecodeError):
         return {}
 
 

--- a/pre_commit_hooks/js_syntax_check.py
+++ b/pre_commit_hooks/js_syntax_check.py
@@ -22,7 +22,7 @@ def _check_node_available() -> bool:
             capture_output=True,
             timeout=5,
         )
-    except FileNotFoundError, subprocess.TimeoutExpired:
+    except (FileNotFoundError, subprocess.TimeoutExpired):
         return False
     else:
         return True

--- a/pre_commit_hooks/no_sync_in_async.py
+++ b/pre_commit_hooks/no_sync_in_async.py
@@ -120,7 +120,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for filename in args.filenames:
         try:
             source = Path(filename).read_text(encoding='utf-8')
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
         for fname, lineno, msg in detect_sync_in_async(source, filename):
             print(f'{fname}:{lineno}: {msg}', file=sys.stderr)

--- a/pre_commit_hooks/python_no_type_ignore.py
+++ b/pre_commit_hooks/python_no_type_ignore.py
@@ -47,7 +47,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for filename in args.filenames:
         try:
             source = Path(filename).read_text(encoding='utf-8')
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
         for fname, lineno, msg in detect_bare_type_ignore(source, filename):
             print(f'{fname}:{lineno}: {msg}')

--- a/pre_commit_hooks/regression_gate.py
+++ b/pre_commit_hooks/regression_gate.py
@@ -42,7 +42,7 @@ def _parse_coverage(report_path: Path) -> float | None:
         line_rate = tree.getroot().get('line-rate')
         if line_rate is not None:
             return round(float(line_rate) * 100, 2)
-    except ElementTree.ParseError, ValueError, OSError:
+    except (ElementTree.ParseError, ValueError, OSError):
         pass
     return None
 
@@ -73,7 +73,7 @@ def _parse_test_count(report_path: Path) -> int | None:
             1 for tc in root.iter('testcase') if not (tc.find('failure') is not None or tc.find('error') is not None)
         )
         return passed
-    except ElementTree.ParseError, ValueError, OSError:
+    except (ElementTree.ParseError, ValueError, OSError):
         pass
     return None
 
@@ -84,7 +84,7 @@ def _load_baseline(path: Path) -> dict | None:
         return None
     try:
         return json.loads(path.read_text(encoding='utf-8'))
-    except json.JSONDecodeError, OSError:
+    except (json.JSONDecodeError, OSError):
         return None
 
 

--- a/pre_commit_hooks/ts_hardcoded_secret.py
+++ b/pre_commit_hooks/ts_hardcoded_secret.py
@@ -84,7 +84,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     for filename in args.filenames:
         try:
             source = Path(filename).read_text(encoding='utf-8')
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
         for fname, lineno, msg in detect_hardcoded_secrets(source, filename):
             print(f'{fname}:{lineno}: {msg}')  # print-detection: disable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,8 @@ addopts = "-v --tb=short --cov-fail-under=85"
 
 [tool.ruff]
 line-length = 120
-target-version = "py314"
+# py313 (not py314): ruff format <=0.15.15 strips multi-except parens under py314 — restore when fixed upstream
+target-version = "py313"
 
 [tool.ruff.lint]
 select = [

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -108,7 +108,7 @@ class QualityGate:
         try:
             d = json.loads(output)
             return sum(len(v) for v in d.get('results', {}).values())
-        except json.JSONDecodeError, AttributeError, ValueError:
+        except (json.JSONDecodeError, AttributeError, ValueError):
             pass
         match = re.search(r'secrets?\s+found[:\s]+(\d+)', output, re.IGNORECASE)
         if match:


### PR DESCRIPTION
## Problem

`ruff format` with `target-version = "py314"` (ruff 0.15.12 through 0.15.15) strips the parentheses from multi-exception except clauses:

```python
except (TypeError, ValueError):   # ->   except TypeError, ValueError:
```

The second form is **invalid Python 3** (`SyntaxError: multiple exception types must be parenthesized`). The local pre-commit hook had already committed such corrupted clauses to `main`.

## Fix

- Pin `target-version` to `py313` in `config-tools/ruff.toml` and `pyproject.toml` (`[tool.ruff]`), with a comment to restore `py314` once fixed upstream. py313 is unaffected and formats identically otherwise.
- Re-parenthesize every corrupted multi-except clause across 16 files so they parse again:
  - `pre_commit_hooks/css_unused_variable.py`, `fastapi_missing_links.py`, `format_dockerfile.py`, `fastapi_missing_response_model.py`, `python_no_type_ignore.py`, `dockerfile_healthcheck.py`, `env_example_sync.py`, `regression_gate.py` (3 clauses), `ts_hardcoded_secret.py`, `js_syntax_check.py`, `dockerfile_multi_stage_check.py`, `django_hardcoded_secret.py`, `dockerfile_non_root_user.py`, `dockerfile_no_latest.py`, `no_sync_in_async.py`, `scripts/quality_gate.py`

A full AST sweep of all `*.py` now reports zero syntax errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)