### PR TITLE
fix: install git in test image

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,6 +2,11 @@ FROM python:3.14-slim AS deps
 
 WORKDIR /app
 
+# git is required by hooks/tests that inspect the working tree
+# (adr-gate staged-file lookup, dockerfile multi-stage check).
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN pip install --upgrade pip setuptools wheel
 
 COPY pyproject.toml ./


### PR DESCRIPTION
## Problem
`make docker-test` builds `Dockerfile.test` from `python:3.14-slim`, which ships without `git`. Tests that shell out to git (e.g. `test_adr_gate.py::TestGetAllStagedFiles::test_returns_list`) fail with `FileNotFoundError: 'git'` locally, diverging from CI.

## Fix
Install `git` in the deps stage of `Dockerfile.test`.

## Verification
`make docker-test`: the git-dependent failure is gone (`test_returns_list` PASSED).

> Note: one unrelated failure remains — `test_dockerfile_multi_stage_check.py::test_from_scratch_plus_real_ok` (the multi-stage detector wrongly flags a `FROM scratch` + real-base fixture). Pre-existing, not a git issue; worth a separate bug ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)