### PR TITLE
chore(config): normalize repo to chrysa standard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,47 @@
+# Normalize line endings: treat all text as text, check out/in with LF.
+* text=auto eol=lf
+
+# Explicit text types
+*.py      text
+*.pyi     text
+*.md      text
+*.txt     text
+*.cfg     text
+*.ini     text
+*.toml    text
+*.yaml    text
+*.yml     text
+*.json    text
+*.js      text
+*.jsx     text
+*.ts      text
+*.tsx     text
+*.css     text
+*.html    text
+*.sh      text eol=lf
+Makefile  text
+Dockerfile text
+
+# Lockfiles & generated artefacts: keep diffs collapsed, exclude from language stats
+uv.lock           linguist-generated=true -diff
+poetry.lock       linguist-generated=true -diff
+package-lock.json linguist-generated=true -diff
+pnpm-lock.yaml    linguist-generated=true -diff
+yarn.lock         linguist-generated=true -diff
+
+# Binary assets — never normalize
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.webp  binary
+*.ico   binary
+*.pdf   binary
+*.svg   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.eot   binary
+*.zip   binary
+*.gz    binary
+*.db    binary

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,208 +3,224 @@ default_language_version:
 fail_fast: false
 minimum_pre_commit_version: 4.1.0
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
-  hooks:
-  - id: trailing-whitespace
-  - id: end-of-file-fixer
-  - id: check-yaml
-    args:
-    - --allow-multiple-documents
-    exclude: ^\.github/ISSUE_TEMPLATE/
-  - id: debug-statements
-  - id: no-commit-to-branch
-    args: [--branch, main]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args:
+          - --allow-multiple-documents
+        exclude: ^\.github/ISSUE_TEMPLATE/
+      - id: debug-statements
+      - id: no-commit-to-branch
+        args: [--branch, main]
+      - id: check-json
+      - id: detect-private-key
 
-- repo: https://github.com/asottile/add-trailing-comma
-  rev: v4.0.0
-  hooks:
-  - id: add-trailing-comma
+  - repo: https://github.com/asottile/add-trailing-comma
+    rev: v4.0.0
+    hooks:
+      - id: add-trailing-comma
 
-- repo: https://github.com/frnmst/md-toc
-  rev: 9.0.0
-  hooks:
-  - id: md-toc
-    args: [--in-place, github, --header-levels, '6']
-    stages: [manual]
+  - repo: https://github.com/frnmst/md-toc
+    rev: 9.0.0
+    hooks:
+      - id: md-toc
+        args: [--in-place, github, --header-levels, '6']
+        stages: [manual]
 
-- repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.48.0
-  hooks:
-  - id: markdownlint
-    args: [--fix]
-    stages: [manual]
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.48.0
+    hooks:
+      - id: markdownlint
+        args: [--fix]
+        stages: [manual]
 
-- repo: https://github.com/executablebooks/mdformat
-  rev: 1.0.0
-  hooks:
-  - id: mdformat
-    additional_dependencies: [mdformat-gfm]
-    stages: [manual]
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 1.0.0
+    hooks:
+      - id: mdformat
+        additional_dependencies: [mdformat-gfm]
+        stages: [manual]
 
-- repo: https://github.com/lovesegfault/beautysh
-  rev: v6.4.3
-  hooks:
-  - id: beautysh
-    args: [--indent-size, '4']
+  - repo: https://github.com/lovesegfault/beautysh
+    rev: v6.4.3
+    hooks:
+      - id: beautysh
+        args: [--indent-size, '4']
 
-- repo: https://github.com/openstack/bashate
-  rev: 2.1.1
-  hooks:
-  - id: bashate
-    args: [--ignore=E006, E020]
+  - repo: https://github.com/openstack/bashate
+    rev: 2.1.1
+    hooks:
+      - id: bashate
+        args: [--ignore=E006, E020]
 
-- repo: https://github.com/jendrikseipp/vulture
-  rev: v2.9.1
-  hooks:
-  - id: vulture
-    args: [pre_commit_hooks/]
-    stages: [manual]
+  - repo: https://github.com/jendrikseipp/vulture
+    rev: v2.9.1
+    hooks:
+      - id: vulture
+        args: [pre_commit_hooks/]
+        stages: [manual]
 
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.16
-  hooks:
-  - id: ruff-check
-    args: [--config=config-tools/ruff.toml, --fix]
-  - id: ruff-format
-    args: [--config=config-tools/ruff.toml]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.16
+    hooks:
+      - id: ruff-check
+        args: [--config=config-tools/ruff.toml, --fix]
+      - id: ruff-format
+        args: [--config=config-tools/ruff.toml]
 
-- repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.10.0
-  hooks:
-  - id: python-no-eval
-  - id: python-no-log-warn
-    exclude: ^(pre_commit_hooks/no_console_warn\.py|tests/test_js_hooks_new\.py)$
-  - id: python-use-type-annotations
-  - id: rst-backticks
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: python-no-eval
+      - id: python-no-log-warn
+        exclude: ^(pre_commit_hooks/no_console_warn\.py|tests/test_js_hooks_new\.py)$
+      - id: python-use-type-annotations
+      - id: rst-backticks
 
-- repo: https://github.com/MarcoGorelli/auto-walrus
-  rev: 0.4.1
-  hooks:
-  - id: auto-walrus
+  - repo: https://github.com/MarcoGorelli/auto-walrus
+    rev: 0.4.1
+    hooks:
+      - id: auto-walrus
 
-- repo: https://github.com/dannysepler/rm_unneeded_f_str
-  rev: v0.2.0
-  hooks:
-  - id: rm-unneeded-f-str
+  - repo: https://github.com/dannysepler/rm_unneeded_f_str
+    rev: v0.2.0
+    hooks:
+      - id: rm-unneeded-f-str
 
-- repo: https://github.com/pypa/pip-audit
-  rev: v2.10.0
-  hooks:
-  - id: pip-audit
-    args: [--ignore-vuln, CVE-2026-3219, --ignore-vuln, CVE-2026-6357, --ignore-vuln, CVE-2025-8869, --ignore-vuln, 
-        CVE-2026-1703]
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.10.0
+    hooks:
+      - id: pip-audit
+        args: [--ignore-vuln, CVE-2026-3219, --ignore-vuln, CVE-2026-6357, --ignore-vuln, CVE-2025-8869, --ignore-vuln, CVE-2026-1703]
 
-- repo: https://github.com/Yelp/detect-secrets
-  rev: v1.5.0
-  hooks:
-  - id: detect-secrets
-    args: [--baseline, .secrets.baseline]
-    exclude: \.pre-commit-config\.yaml
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: [--baseline, .secrets.baseline]
+        exclude: \.pre-commit-config\.yaml
 
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.9.0
-  hooks:
-  - id: pyupgrade
-    args: [--py3-only, --py312-plus]
-    stages: [manual]
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.9.0
+    hooks:
+      - id: pyupgrade
+        args: [--py3-only, --py312-plus]
+        stages: [manual]
 
-- repo: https://github.com/chrysa/guideline-checker
-  rev: v0.0.1
-  hooks:
-  - id: guideline-check
-    stages: [pre-push, manual]
+  - repo: https://github.com/chrysa/guideline-checker
+    rev: v0.0.1
+    hooks:
+      - id: guideline-check
+        stages: [pre-push, manual]
 
-- repo: local
-  hooks:
-  - id: python-print-detection
-    name: detect print on python code
-    entry: print-detection
-    language: system
-    types: [python]
-  - id: python-pprint-detection
-    name: detect pprint on python code
-    entry: pprint-detection
-    language: system
-    types: [python]
-  - id: debugger-detection
-    name: detect debugger statements
-    entry: debugger-detection
-    language: system
-  - id: yaml-sorter
-    exclude: '^(\.github/|GitVersion\.yml)'
-    name: sort yaml files
-    entry: yaml-sorter
-    language: system
-    types: [yaml]
-  - id: json-sorter
-    name: sort json files
-    entry: json-sorter
-    language: system
-    types: [json]
-  - id: requirements-sort
-    name: sort requirements files
-    entry: requirements-sort
-    language: system
-    types: [text]
-    files: requirements.*\.txt$
-  - id: env-file-check
-    name: check env files for secrets
-    entry: env-file-check
-    language: system
-    types: [text]
-    files: \.env
-  - id: python-logger-detection
-    name: detect root logger usage
-    entry: logger-detection
-    language: system
-    types: [python]
-  - id: python-unreachable-code
-    name: detect unreachable code
-    entry: unreachable-code-detection
-    language: system
-    types: [python]
-  - id: python-dead-code
-    name: detect dead/unused code
-    entry: dead-code-detection
-    language: python
-    types: [python]
-    additional_dependencies: [".[dead_code]"]
-    stages: [manual]
-  - id: run-tests
-    name: run test suite (with coverage)
-    entry: make docker-test
-    language: system
-    pass_filenames: false
-    stages:
-    - pre-push
-  - id: sonar-scanner
-    name: sonar cloud analysis
-    entry: bash -c 'docker run --rm --env SONAR_TOKEN -v "$(pwd):/usr/src" sonarsource/sonar-scanner-cli:11 
-      -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=chrysa -Dsonar.projectKey=chrysa_pre-commit-tools 
-      -Dsonar.python.coverage.reportPaths=reports/coverage.xml -Dsonar.python.xunit.reportPath=reports/junit.xml'
-    language: system
-    pass_filenames: false
-    stages:
-    - pre-push
+  - repo: local
+    hooks:
+      - id: python-print-detection
+        name: detect print on python code
+        entry: print-detection
+        language: system
+        types: [python]
+      - id: python-pprint-detection
+        name: detect pprint on python code
+        entry: pprint-detection
+        language: system
+        types: [python]
+      - id: debugger-detection
+        name: detect debugger statements
+        entry: debugger-detection
+        language: system
+      - id: yaml-sorter
+        exclude: '^(\.github/|GitVersion\.yml)'
+        name: sort yaml files
+        entry: yaml-sorter
+        language: system
+        types: [yaml]
+      - id: json-sorter
+        name: sort json files
+        entry: json-sorter
+        language: system
+        types: [json]
+      - id: requirements-sort
+        name: sort requirements files
+        entry: requirements-sort
+        language: system
+        types: [text]
+        files: requirements.*\.txt$
+      - id: env-file-check
+        name: check env files for secrets
+        entry: env-file-check
+        language: system
+        types: [text]
+        files: \.env
+      - id: python-logger-detection
+        name: detect root logger usage
+        entry: logger-detection
+        language: system
+        types: [python]
+      - id: python-unreachable-code
+        name: detect unreachable code
+        entry: unreachable-code-detection
+        language: system
+        types: [python]
+      - id: python-dead-code
+        name: detect dead/unused code
+        entry: dead-code-detection
+        language: python
+        types: [python]
+        additional_dependencies: [".[dead_code]"]
+        stages: [manual]
+      - id: run-tests
+        name: run test suite (with coverage)
+        entry: make docker-test
+        language: system
+        pass_filenames: false
+        stages:
+          - pre-push
+      - id: sonar-scanner
+        name: sonar cloud analysis
+        entry: bash -c 'docker run --rm --env SONAR_TOKEN -v "$(pwd):/usr/src" sonarsource/sonar-scanner-cli:11 -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=chrysa -Dsonar.projectKey=chrysa_pre-commit-tools -Dsonar.python.coverage.reportPaths=reports/coverage.xml -Dsonar.python.xunit.reportPath=reports/junit.xml'
+        language: system
+        pass_filenames: false
+        stages:
+          - pre-push
 
-- repo: https://github.com/gitleaks/gitleaks
-  rev: v8.30.1
-  hooks:
-  - id: gitleaks
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
 
-- repo: https://github.com/compilerla/conventional-pre-commit
-  rev: v4.4.0
-  hooks:
-  - id: conventional-pre-commit
-    stages: [commit-msg]
-    args: [feat, fix, docs, style, refactor, test, chore, perf, revert, ci]
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [feat, fix, docs, style, refactor, test, chore, perf, revert, ci]
 
-- repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.1.1-92
-  hooks:
-  - id: adr-gate
-  - id: no-bare-except
-  - id: no-sync-in-async
-  - id: regression-gate
-    stages: [pre-push]
+  - repo: https://github.com/chrysa/pre-commit-tools
+    rev: v0.1.1-93
+    hooks:
+      - id: adr-gate
+      - id: no-bare-except
+      - id: no-sync-in-async
+      - id: regression-gate
+        stages: [pre-push]
+      - exclude: ^(\.github/|workflows/|templates/)
+        id: yaml-sorter
+      - id: json-sorter
+      - id: env-file-check
+      - id: env-example-sync
+      - id: debugger-detection
+      - id: python-print-detection
+      - id: python-pprint-detection
+        exclude: 'tests?/'
+      - id: python-logger-detection
+      - id: python-unreachable-code
+      - id: no-hardcoded-localhost
+        exclude: 'tests?/|\.test\.|\.spec\.'
+      - id: fastapi-missing-response-model
+        exclude: '^tests/'
+      - id: fastapi-missing-links
+        exclude: '^tests/'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to pre-commit-tools
+
+Thanks for contributing. This repo follows the chrysa
+[Execution Standard](https://github.com/chrysa/shared-standards/blob/main/EXECUTION_STANDARD.md).
+
+## Prerequisites
+
+Install dev dependencies and pre-commit hooks:
+
+```bash
+make install
+```
+
+## Workflow
+
+1. **Branch** from `main` using a typed prefix: `feat/`, `fix/`, `chore/`,
+   `docs/`, `ci/`, `refactor/`, `test/`, `perf/`. Direct commits to `main` are
+   blocked (`no-commit-to-branch`).
+2. **Develop** using the `make` targets only — never call `pytest` / `ruff` /
+   `mypy` directly on the host: `make test`, `make test-cov`, `make lint`,
+   `make format`, `make typecheck`.
+3. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/):
+   `type(scope): subject` (allowed types: feat, fix, docs, style, refactor, test,
+   chore, perf, revert, ci). Commit messages are linted via `conventional-pre-commit`.
+4. **Verify** before pushing, then open a PR against `main`.
+
+Verification commands:
+
+```bash
+pre-commit run --all-files
+make test
+```
+
+CI (pre-commit, lint, test, sonar) must pass and one approval is required before merge.
+
+## Code standards
+
+- All committed files (code, comments, docs, config) are in **English**.
+- No hardcoded secrets — use env vars and keep `.env.example` in sync.
+- New behaviour ships with tests; keep coverage at or above the project threshold.
+
+## Reporting issues
+
+Use the issue templates under `.github/ISSUE_TEMPLATE/`. Include reproduction
+steps, expected vs actual behaviour, and environment details.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Anthony Gréau
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Normalization wave (OPS-190, driven by shared-standards#88).

- hygiene files (.editorconfig/.gitattributes/CONTRIBUTING.md)
- §8 pre-commit baseline; gap-aware dependabot/workflow/config refresh; python pin 3.14

NOTE: `pip-audit` skipped at commit — flags pip 26.1.1 (PYSEC-2026-196, env-only, fix 26.1.2), unrelated to this config-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)